### PR TITLE
update README hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@
 
 - Learn how to build for different configurations, like Release or Debug and build shared or static libraries. [Docs](https://docs.conan.io/en/2.0-alpha/tutorial/consuming_packages/getting_started/different_configurations.html)
 
-### [Using conanfile.py vs conanfile.txt](ttutorial/consuming_packages/conanfile_py/)
+### [Using conanfile.py vs conanfile.txt](tutorial/consuming_packages/conanfile_py/)
 
 - Learn about the flexibility of using a conanfile.py instead a conanfile.txt. [Docs](https://docs.conan.io/en/2.0-alpha/tutorial/consuming_packages/getting_started/the_power_of_conanfile_py.html)

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 ## Examples - Tutorial
 
-### [Build a simple CMake project using Conan](tutorial/consuming_packages/getting_started/simple_cmake_project/)
+### [Build a simple CMake project using Conan](tutorial/consuming_packages/simple_cmake_project/)
 
 - Use Conan to manage dependencies for a simple application, a string compressor that uses Zlib. [Docs](https://docs.conan.io/en/2.0-alpha/tutorial/consuming_packages/getting_started/build_simple_cmake_project.html)
 
-### [Using build tools as Conan packages](tutorial/consuming_packages/getting_started/tool_requires/)
+### [Using build tools as Conan packages](tutorial/consuming_packages/tool_requires/)
 
 - Use Conan to install and use build tools like CMake. [Docs](https://docs.conan.io/en/2.0-alpha/tutorial/consuming_packages/getting_started/use_tools_as_conan_packages.html)
 
-### [Building for multiple configurations: Release, Debug, Static and Shared](tutorial/consuming_packages/getting_started/different_configurations/)
+### [Building for multiple configurations: Release, Debug, Static and Shared](tutorial/consuming_packages/different_configurations/)
 
 - Learn how to build for different configurations, like Release or Debug and build shared or static libraries. [Docs](https://docs.conan.io/en/2.0-alpha/tutorial/consuming_packages/getting_started/different_configurations.html)
 
-### [Using conanfile.py vs conanfile.txt](ttutorial/consuming_packages/getting_started/conanfile_py/)
+### [Using conanfile.py vs conanfile.txt](ttutorial/consuming_packages/conanfile_py/)
 
 - Learn about the flexibility of using a conanfile.py instead a conanfile.txt. [Docs](https://docs.conan.io/en/2.0-alpha/tutorial/consuming_packages/getting_started/the_power_of_conanfile_py.html)


### PR DESCRIPTION
after some [file relocation](https://github.com/conan-io/examples2/pull/9) the hyperlinks within the topmost readme are outdated and therefore unreachable.