### PR TITLE
[dev2] Custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@
 
 ### [Use custom commands in your Conan CLI](examples/extensions/commands/)
 
-- Learn how to create custom commands in Conan. [Docs](https://docs.conan.io/en/2.0-alpha/reference/commands/custom_commands.html)
+- Learn how to create custom commands in Conan. [Docs](https://docs.conan.io/en/2.0/reference/commands/custom_commands.html)
 
-    * ``conan clean`` [command](examples/extensions/commands/clean/cmd_clean.py): Deletes (from local cache or remotes) all recipe and package revisions but the latest package revision from the latest recipe revision. [Docs](https://docs.conan.io/en/2.0-alpha/examples/extensions/commands/clean/custom_command_clean_revisions.html)
+    * ``conan clean`` [command](examples/extensions/commands/clean/cmd_clean.py): Deletes (from local cache or remotes) all recipe and package revisions but the latest package revision from the latest recipe revision. [Docs](https://docs.conan.io/en/2.0/examples/extensions/commands/clean/custom_command_clean_revisions.html)

--- a/README.md
+++ b/README.md
@@ -67,3 +67,11 @@
 #### [How to create a Conan package for prebuilt binaries in a remote](tutorial/creating_packages/other_packages/prebuilt_remote_binaries/)
 
 - Learn how to create a Conan package when we have prebuilt libraries located in a remote repository. [Docs](https://docs.conan.io/en/2.0/tutorial/creating_packages/other_types_of_packages/package_prebuilt_binaries.html#downloading-and-packaging-pre-built-binaries)
+
+## Examples
+
+### [Use custom commands in your Conan CLI](examples/extensions/commands/)
+
+- Learn how to create custom commands in Conan. [Docs](https://docs.conan.io/en/2.0-alpha/reference/commands/custom_commands.html)
+
+    * ``conan clean`` [command](examples/extensions/commands/clean/cmd_clean.py): Deletes (from local cache or remotes) all recipe and package revisions but the latest package revision from the latest recipe revision. [Docs](https://docs.conan.io/en/2.0-alpha/examples/extensions/commands/clean/custom_command_clean_revisions.html)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -1,0 +1,52 @@
+from conan.api.conan_api import ConanAPIV2
+from conans.cli.command import conan_command, OnceArgument
+from conans.cli.output import Color, ConanOutput
+from conans.client.userio import UserInput
+
+info_color = Color.BRIGHT_WHITE
+recipe_color = Color.BRIGHT_BLUE
+removed_color = Color.BRIGHT_YELLOW
+
+
+@conan_command(group="Custom commands")
+def clean(conan_api: ConanAPIV2, parser, *args):
+    """
+    Deletes (from local cache or remotes) all recipe and package revisions but
+    the latest package revision from the latest recipe revision.
+    """
+    parser.add_argument('-r', '--remote', action=OnceArgument,
+                        help='Will remove from the specified remote')
+    parser.add_argument('--force', default=False, action='store_true',
+                        help='Remove without requesting a confirmation')
+    args = parser.parse_args(*args)
+
+    def confirmation(message):
+        return args.force or ui.request_boolean(message)
+
+    out = ConanOutput()
+    ui = UserInput(conan_api.config.get("core:non_interactive"))
+    remote = conan_api.remotes.get(args.remote) if args.remote else None
+    output_remote = remote or "Local cache"
+    # Getting all the recipes
+    recipes = conan_api.search.recipes("*/*", remote=remote)
+    for recipe in recipes:
+        out.writeln(f"{str(recipe)}", fg=recipe_color)
+        # All RREVS and latest one
+        all_rrevs = conan_api.list.recipe_revisions(recipe, remote=remote)
+        latest_rrev = all_rrevs.pop(0) if all_rrevs else None
+        if latest_rrev:
+            # All PREVS and latest one (belonging to latest RREV)
+            all_prevs = conan_api.search.package_revisions(f"{latest_rrev.repr_notime()}:*#*", remote=remote)
+            latest_prev = all_prevs.pop(0) if all_prevs else None
+            if latest_prev:
+                out.writeln(f"  Keeping latest PREV: {latest_prev.repr_notime()} [{output_remote}]", fg=info_color)
+            # Removing all the earlier package revisions of the latest recipe revision
+            if all_prevs and confirmation(f"Remove all the {latest_rrev.repr_notime()} package revisions but the last one ?"):
+                for prev in all_prevs:
+                    conan_api.remove.package(prev, remote=remote)
+                    out.writeln(f"  Removed PREV: {prev.repr_notime()} [{output_remote}]", fg=removed_color)
+        # Removing all the earlier recipe revisions (and its packages)
+        if all_rrevs and confirmation(f"Remove all the {str(recipe)} recipe revisions but the last one ?"):
+            for rrev in all_rrevs:
+                conan_api.remove.recipe(rrev, remote=remote)
+                out.writeln(f"  Removed RREV: {rrev.repr_notime()} [{output_remote}]", fg=removed_color)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -22,29 +22,34 @@ def clean(conan_api: ConanAPIV2, parser, *args):
 
     def confirmation(message):
         """
-        Returns True or False if "--force" was passed or if user answers "yes" or "no" to the question message
+        Returns True if "--force" was passed or if user answers "yes" to the question message, otherwise, False
         """
         return args.force or ui.request_boolean(message)
 
-    def remove_all_recipe_revisions(rrevs):
+    def remove_all_recipe_revisions_but_latest_one(rrevs):
         """
-        Remove all the given recipes through ConanAPIV2.remove.recipe
+        Remove all the given recipes through ConanAPIV2.remove.recipe but the latest one (the first on the list given)
         """
         # Removing all the earlier recipe revisions (and its packages)
-        if rrevs and confirmation(f"Remove all the {str(recipe)} recipe revisions but the last one?"):
-            for rrev in rrevs:
+        if len(rrevs) > 1 and confirmation(f"Remove all the {str(recipe)} recipe revisions but the last one?"):
+            for rrev in rrevs[1:]:
                 conan_api.remove.recipe(rrev, remote=remote)
                 out.writeln(f"  Removed RREV: {rrev.repr_notime()} [{output_remote}]", fg=removed_color)
 
-    def remove_all_package_revisions(prevs):
+        return rrevs[0] if rrevs else None
+
+    def remove_all_package_revisions_but_latest_one(prevs):
         """
-        Remove all the given packages through ConanAPIV2.remove.package
+        Remove all the given packages through ConanAPIV2.remove.package but the latest one (the first on the list given)
         """
         # Removing all the earlier package revisions of the latest recipe revision
-        if prevs and confirmation(f"Remove all the {latest_rrev.repr_notime()} package revisions but the last one?"):
-            for prev in prevs:
+        if len(prevs) > 1 and confirmation(f"Remove all the {latest_rrev.repr_notime()} package revisions "
+                                           f"but the last one?"):
+            for prev in prevs[1:]:
                 conan_api.remove.package(prev, remote=remote)
                 out.writeln(f"  Removed PREV: {prev.repr_notime()} [{output_remote}]", fg=removed_color)
+
+        return prevs[0] if prevs else None
 
     out = ConanOutput()
     ui = UserInput(conan_api.config.get("core:non_interactive"))
@@ -56,16 +61,12 @@ def clean(conan_api: ConanAPIV2, parser, *args):
         out.writeln(f"{str(recipe)}", fg=recipe_color)
         # Get all the RREVs (recipe revisions)
         all_rrevs = conan_api.list.recipe_revisions(recipe, remote=remote)
-        # Save the latest RREV (it's the first one from the list)
-        latest_rrev = all_rrevs.pop(0) if all_rrevs else None
-        # Remove the rest of RREVs and their packages
-        remove_all_recipe_revisions(all_rrevs)
+        # Save the latest RREV and remove the rest ones
+        latest_rrev = remove_all_recipe_revisions_but_latest_one(all_rrevs)
         if latest_rrev:
             # Get all the PREVs (package revisions) belonging to latest RREV
             all_prevs = conan_api.search.package_revisions(f"{latest_rrev.repr_notime()}:*#*", remote=remote)
-            # Save the latest PREV (it's the first one from the list)
-            latest_prev = all_prevs.pop(0) if all_prevs else None
+            # Save the latest PREV and remove the rest ones
+            latest_prev = remove_all_package_revisions_but_latest_one(all_prevs)
             if latest_prev:
                 out.writeln(f"  Keeping latest PREV: {latest_prev.repr_notime()} [{output_remote}]", fg=info_color)
-            # Remove the rest of PREVs
-            remove_all_package_revisions(all_prevs)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -26,29 +26,25 @@ def clean(conan_api: ConanAPIV2, parser, *args):
         """
         return args.force or ui.request_boolean(message)
 
-    def remove_all_recipe_revisions_but_latest_one(rrevs):
+    def remove_all_recipe_revisions_but_latest_one(recipe_, rrevs):
         """
         Remove all the given recipes through ConanAPIV2.remove.recipe but the latest one (the first on the list given)
         """
-        # Removing all the earlier recipe revisions (and its packages)
-        if len(rrevs) > 1 and confirmation(f"Remove all the {str(recipe)} recipe revisions but the last one?"):
+        if len(rrevs) > 1 and confirmation(f"Remove all the {str(recipe_)} recipe revisions but the last one?"):
             for rrev in rrevs[1:]:
                 conan_api.remove.recipe(rrev, remote=remote)
                 out.writeln(f"  Removed RREV: {rrev.repr_notime()} [{output_remote}]", fg=removed_color)
-
         return rrevs[0] if rrevs else None
 
-    def remove_all_package_revisions_but_latest_one(prevs):
+    def remove_all_package_revisions_but_latest_one(rrev, prevs):
         """
         Remove all the given packages through ConanAPIV2.remove.package but the latest one (the first on the list given)
         """
-        # Removing all the earlier package revisions of the latest recipe revision
-        if len(prevs) > 1 and confirmation(f"Remove all the {latest_rrev.repr_notime()} package revisions "
+        if len(prevs) > 1 and confirmation(f"Remove all the {rrev.repr_notime()} package revisions "
                                            f"but the last one?"):
             for prev in prevs[1:]:
                 conan_api.remove.package(prev, remote=remote)
                 out.writeln(f"  Removed PREV: {prev.repr_notime()} [{output_remote}]", fg=removed_color)
-
         return prevs[0] if prevs else None
 
     out = ConanOutput()
@@ -62,11 +58,11 @@ def clean(conan_api: ConanAPIV2, parser, *args):
         # Get all the RREVs (recipe revisions)
         all_rrevs = conan_api.list.recipe_revisions(recipe, remote=remote)
         # Save the latest RREV and remove the rest ones
-        latest_rrev = remove_all_recipe_revisions_but_latest_one(all_rrevs)
+        latest_rrev = remove_all_recipe_revisions_but_latest_one(recipe, all_rrevs)
         if latest_rrev:
             # Get all the PREVs (package revisions) belonging to latest RREV
             all_prevs = conan_api.search.package_revisions(f"{latest_rrev.repr_notime()}:*#*", remote=remote)
             # Save the latest PREV and remove the rest ones
-            latest_prev = remove_all_package_revisions_but_latest_one(all_prevs)
+            latest_prev = remove_all_package_revisions_but_latest_one(latest_rrev, all_prevs)
             if latest_prev:
                 out.writeln(f"  Keeping latest PREV: {latest_prev.repr_notime()} [{output_remote}]", fg=info_color)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -1,9 +1,7 @@
 from conan.api.conan_api import ConanAPIV2
 from conans.cli.command import conan_command, OnceArgument
 from conans.cli.output import Color, ConanOutput
-from conans.client.userio import UserInput
 
-info_color = Color.BRIGHT_WHITE
 recipe_color = Color.BRIGHT_BLUE
 removed_color = Color.BRIGHT_YELLOW
 
@@ -16,53 +14,26 @@ def clean(conan_api: ConanAPIV2, parser, *args):
     """
     parser.add_argument('-r', '--remote', action=OnceArgument,
                         help='Will remove from the specified remote')
-    parser.add_argument('--force', default=False, action='store_true',
-                        help='Remove without requesting a confirmation')
     args = parser.parse_args(*args)
-
-    def confirmation(message):
-        """
-        Returns True if "--force" was passed or if user answers "yes" to the question message, otherwise, False
-        """
-        return args.force or ui.request_boolean(message)
-
-    def remove_all_recipe_revisions_but_latest_one(recipe_, rrevs):
-        """
-        Remove all the given recipes through ConanAPIV2.remove.recipe but the latest one (the first on the list given)
-        """
-        if len(rrevs) > 1 and confirmation(f"Remove all the {str(recipe_)} recipe revisions but the last one?"):
-            for rrev in rrevs[1:]:
-                conan_api.remove.recipe(rrev, remote=remote)
-                out.writeln(f"  Removed RREV: {rrev.repr_notime()} [{output_remote}]", fg=removed_color)
-        return rrevs[0] if rrevs else None
-
-    def remove_all_package_revisions_but_latest_one(rrev, prevs):
-        """
-        Remove all the given packages through ConanAPIV2.remove.package but the latest one (the first on the list given)
-        """
-        if len(prevs) > 1 and confirmation(f"Remove all the {rrev.repr_notime()} package revisions "
-                                           f"but the last one?"):
-            for prev in prevs[1:]:
-                conan_api.remove.package(prev, remote=remote)
-                out.writeln(f"  Removed PREV: {prev.repr_notime()} [{output_remote}]", fg=removed_color)
-        return prevs[0] if prevs else None
-
     out = ConanOutput()
-    ui = UserInput(conan_api.config.get("core:non_interactive"))
     remote = conan_api.remotes.get(args.remote) if args.remote else None
     output_remote = remote or "Local cache"
     # Getting all the recipes
     recipes = conan_api.search.recipes("*/*", remote=remote)
     for recipe in recipes:
         out.writeln(f"{str(recipe)}", fg=recipe_color)
-        # Get all the RREVs (recipe revisions)
         all_rrevs = conan_api.list.recipe_revisions(recipe, remote=remote)
-        # Save the latest RREV and remove the rest ones
-        latest_rrev = remove_all_recipe_revisions_but_latest_one(recipe, all_rrevs)
-        if latest_rrev:
-            # Get all the PREVs (package revisions) belonging to latest RREV
-            all_prevs = conan_api.search.package_revisions(f"{latest_rrev.repr_notime()}:*#*", remote=remote)
-            # Save the latest PREV and remove the rest ones
-            latest_prev = remove_all_package_revisions_but_latest_one(latest_rrev, all_prevs)
-            if latest_prev:
-                out.writeln(f"  Keeping latest PREV: {latest_prev.repr_notime()} [{output_remote}]", fg=info_color)
+        latest_rrev = all_rrevs[0] if all_rrevs else None
+        for rrev in all_rrevs:
+            if rrev != latest_rrev:
+                conan_api.remove.recipe(rrev, remote=remote)
+                out.writeln(f"Removed recipe revision: {rrev.repr_notime()} [{output_remote}] "
+                            f"and all package revisions", fg=removed_color)
+            else:
+                all_prevs = conan_api.search.package_revisions(f"{rrev.repr_notime()}:*#*", remote=remote)
+                latest_prev = all_prevs[0] if all_prevs else None
+                for prev in all_prevs:
+                    if prev != latest_prev:
+                        conan_api.remove.package(prev, remote=remote)
+                        out.writeln(f"Removed package revision: {prev.repr_notime()} [{output_remote}] "
+                                    f"from recipe revision: {rrev.repr_notime()} [{output_remote}]", fg=removed_color)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -39,13 +39,12 @@ def clean(conan_api: ConanAPIV2, parser, *args):
         for rrev in all_rrevs:
             if rrev != latest_rrev:
                 conan_api.remove.recipe(rrev, remote=remote)
-                out.writeln(f"Removed recipe revision: {rrev.repr_notime()} [{output_remote}] "
-                            f"and all package revisions", fg=removed_color)
+                out.writeln(f"Removed recipe revision: {rrev.repr_notime()} "
+                            f"and all its package revisions [{output_remote}]", fg=removed_color)
             else:
                 all_prevs = conan_api.search.package_revisions(f"{rrev.repr_notime()}:*#*", remote=remote)
                 latest_prev = all_prevs[0] if all_prevs else None
                 for prev in all_prevs:
                     if prev != latest_prev:
                         conan_api.remove.package(prev, remote=remote)
-                        out.writeln(f"Removed package revision: {prev.repr_notime()} [{output_remote}] "
-                                    f"from recipe revision: {rrev.repr_notime()} [{output_remote}]", fg=removed_color)
+                        out.writeln(f"Removed package revision: {prev.repr_notime()} [{output_remote}]", fg=removed_color)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -21,7 +21,30 @@ def clean(conan_api: ConanAPIV2, parser, *args):
     args = parser.parse_args(*args)
 
     def confirmation(message):
+        """
+        Returns True or False if "--force" was passed or if user answers "yes" or "no" to the question message
+        """
         return args.force or ui.request_boolean(message)
+
+    def remove_all_recipe_revisions(rrevs):
+        """
+        Remove all the given recipes through ConanAPIV2.remove.recipe
+        """
+        # Removing all the earlier recipe revisions (and its packages)
+        if rrevs and confirmation(f"Remove all the {str(recipe)} recipe revisions but the last one?"):
+            for rrev in rrevs:
+                conan_api.remove.recipe(rrev, remote=remote)
+                out.writeln(f"  Removed RREV: {rrev.repr_notime()} [{output_remote}]", fg=removed_color)
+
+    def remove_all_package_revisions(prevs):
+        """
+        Remove all the given packages through ConanAPIV2.remove.package
+        """
+        # Removing all the earlier package revisions of the latest recipe revision
+        if prevs and confirmation(f"Remove all the {latest_rrev.repr_notime()} package revisions but the last one?"):
+            for prev in prevs:
+                conan_api.remove.package(prev, remote=remote)
+                out.writeln(f"  Removed PREV: {prev.repr_notime()} [{output_remote}]", fg=removed_color)
 
     out = ConanOutput()
     ui = UserInput(conan_api.config.get("core:non_interactive"))
@@ -31,22 +54,18 @@ def clean(conan_api: ConanAPIV2, parser, *args):
     recipes = conan_api.search.recipes("*/*", remote=remote)
     for recipe in recipes:
         out.writeln(f"{str(recipe)}", fg=recipe_color)
-        # All RREVS and latest one
+        # Get all the RREVs (recipe revisions)
         all_rrevs = conan_api.list.recipe_revisions(recipe, remote=remote)
+        # Save the latest RREV (it's the first one from the list)
         latest_rrev = all_rrevs.pop(0) if all_rrevs else None
+        # Remove the rest of RREVs and their packages
+        remove_all_recipe_revisions(all_rrevs)
         if latest_rrev:
-            # All PREVS and latest one (belonging to latest RREV)
+            # Get all the PREVs (package revisions) belonging to latest RREV
             all_prevs = conan_api.search.package_revisions(f"{latest_rrev.repr_notime()}:*#*", remote=remote)
+            # Save the latest PREV (it's the first one from the list)
             latest_prev = all_prevs.pop(0) if all_prevs else None
             if latest_prev:
                 out.writeln(f"  Keeping latest PREV: {latest_prev.repr_notime()} [{output_remote}]", fg=info_color)
-            # Removing all the earlier package revisions of the latest recipe revision
-            if all_prevs and confirmation(f"Remove all the {latest_rrev.repr_notime()} package revisions but the last one ?"):
-                for prev in all_prevs:
-                    conan_api.remove.package(prev, remote=remote)
-                    out.writeln(f"  Removed PREV: {prev.repr_notime()} [{output_remote}]", fg=removed_color)
-        # Removing all the earlier recipe revisions (and its packages)
-        if all_rrevs and confirmation(f"Remove all the {str(recipe)} recipe revisions but the last one ?"):
-            for rrev in all_rrevs:
-                conan_api.remove.recipe(rrev, remote=remote)
-                out.writeln(f"  Removed RREV: {rrev.repr_notime()} [{output_remote}]", fg=removed_color)
+            # Remove the rest of PREVs
+            remove_all_package_revisions(all_prevs)

--- a/examples/extensions/commands/run_example.py
+++ b/examples/extensions/commands/run_example.py
@@ -55,10 +55,10 @@ with tmp_dir("clean_other"):
     run("conan create .")  # different RREV (this is the latest one)
 
 # 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
-output = run("conan clean")
+output = run("conan clean --force")
 assert "Removed package revision: clean_hello/1.0#" in output  # removing earlier PREV from clean_hello
 assert "Removed recipe revision: clean_other/1.0#" in output  # removing earlier RREV from clean_other
 # Now, it should have removed nothing
-output = run("conan clean")
+output = run("conan clean --force")
 assert "Removed recipe revision: clean_other/1.0#" not in output
 assert "Removed package revision: clean_hello/1.0#" not in output

--- a/examples/extensions/commands/run_example.py
+++ b/examples/extensions/commands/run_example.py
@@ -1,0 +1,69 @@
+import os
+
+from test.examples_tools import run, tmp_dir
+
+
+non_deterministic_conanfile = """\
+from datetime import datetime
+
+from conan import ConanFile
+from conan.tools.files import copy
+
+
+class HelloConan(ConanFile):
+    name = "{name}"
+    version = "1.0"
+    {comment}
+
+    def build(self):
+        with open("random.txt", "w") as f:
+            f.write(str(datetime.now()))
+
+    def package(self):
+        # Packaging a random content, the package revision will be different every time
+        copy(self, "random.txt", self.source_folder, self.package_folder)
+"""
+
+
+def install_clean_command():
+    clean_command = os.path.join(os.path.dirname(os.path.realpath(__file__)), "clean")
+    commands_folder = os.path.join("extensions", "commands")
+    run(f"conan config install {clean_command} -tf {commands_folder}")
+
+
+# At first, copy the commands into the ${CONAN_HOME}/extensions/commands folder
+install_clean_command()
+
+# 1. Check the custom command is appearing in conan help
+output = run("conan -h")
+assert "Custom commands\nclean" in output.replace("\r\n", "\n")
+
+# 2. Create several packages
+with tmp_dir("clean_hello"):
+    # Library (changing PREV each time)
+    with open(os.path.join("conanfile.py"), "w") as f:
+        f.write(non_deterministic_conanfile.format(name="clean_hello", comment=""))
+    run("conan create .")
+    run("conan create .")  # different PREV (this is the latest one)
+
+with tmp_dir("clean_other"):
+    with open(os.path.join("conanfile.py"), "w") as f:
+        f.write(non_deterministic_conanfile.format(name="clean_other", comment=""))
+    run("conan create .")
+    # Changing RREV
+    with open(os.path.join("conanfile.py"), "w") as f:
+        f.write(non_deterministic_conanfile.format(name="clean_other", comment="# Changing RREV"))
+    run("conan create .")  # different RREV (this is the latest one)
+
+# 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
+output = run("conan clean --force")
+assert "Keeping latest PREV: clean_hello/1.0#" in output
+assert "Keeping latest PREV: clean_other/1.0#" in output
+assert "Removed PREV: clean_hello/1.0#" in output  # removing earlier PREV from clean_hello
+assert "Removed RREV: clean_other/1.0#" in output  # removing earlier RREV from clean_other
+# Now, it should have removed nothing
+output = run("conan clean --force")
+assert "Keeping latest PREV: clean_hello/1.0#" in output
+assert "Keeping latest PREV: clean_other/1.0#" in output
+assert "Removed RREV: clean_other/1.0#" not in output
+assert "Removed PREV: clean_hello/1.0#" not in output

--- a/examples/extensions/commands/run_example.py
+++ b/examples/extensions/commands/run_example.py
@@ -37,7 +37,6 @@ install_clean_command()
 # 1. Check the custom command is appearing in conan help
 output = run("conan -h")
 assert "Custom commands\nclean" in output.replace("\r\n", "\n")
-
 # 2. Create several packages
 with tmp_dir("clean_hello"):
     # Library (changing PREV each time)
@@ -56,14 +55,10 @@ with tmp_dir("clean_other"):
     run("conan create .")  # different RREV (this is the latest one)
 
 # 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
-output = run("conan clean --force")
-assert "Keeping latest PREV: clean_hello/1.0#" in output
-assert "Keeping latest PREV: clean_other/1.0#" in output
-assert "Removed PREV: clean_hello/1.0#" in output  # removing earlier PREV from clean_hello
-assert "Removed RREV: clean_other/1.0#" in output  # removing earlier RREV from clean_other
+output = run("conan clean")
+assert "Removed package revision: clean_hello/1.0#" in output  # removing earlier PREV from clean_hello
+assert "Removed recipe revision: clean_other/1.0#" in output  # removing earlier RREV from clean_other
 # Now, it should have removed nothing
-output = run("conan clean --force")
-assert "Keeping latest PREV: clean_hello/1.0#" in output
-assert "Keeping latest PREV: clean_other/1.0#" in output
-assert "Removed RREV: clean_other/1.0#" not in output
-assert "Removed PREV: clean_hello/1.0#" not in output
+output = run("conan clean")
+assert "Removed recipe revision: clean_other/1.0#" not in output
+assert "Removed package revision: clean_hello/1.0#" not in output


### PR DESCRIPTION
Custom command: `conan clean`

```txt
$ conan clean -h
usage: conan clean [-h] [-r REMOTE] [--force]

Deletes (from local cache or remotes) all recipe and package revisions but
the latest package revision from the latest recipe revision.
```

For instance:

```bash
$ conan clean
clean_other/1.0
Removed package revision: clean_other/1.0#31da245c3399e4124e39bd4f77b5261f:da39a3ee5e6b4b0d3255bfef95601890afd80709#71085927dd29357380aab1663dc3f93f [Local cache]
Removed recipe revision: clean_other/1.0#721995a35b1a8d840ce634ea1ac71161 and all package revisions [Local cache]
clean_hello/1.0
Removed package revision: clean_hello/1.0#9a77cdcff3a539b5b077dd811b2ae3b0:da39a3ee5e6b4b0d3255bfef95601890afd80709#5a3d2be4a4daf1de3c92359d9f07b996 [Local cache]
Removed package revision: clean_hello/1.0#9a77cdcff3a539b5b077dd811b2ae3b0:da39a3ee5e6b4b0d3255bfef95601890afd80709#99be1e370c3ad0f8644b0691be5c9f7f [Local cache]
```