### PR TITLE
Add deployer sources example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,9 @@
 ### [Use Android NDK to cross-build](examples/cross_build/android/ndk_basic)
 
 - Learn how to cross-build packages for Android. [Docs](https://docs.conan.io/en/2.0/examples/cross_build/android.html)
+
+### [Use custom deployers](examples/extensions/deployers/)
+
+- Learn how to create a custom deployer in Conan. [Docs](https://docs.conan.io/en/2.0/reference/extensions/deployers.html)
+
+    * ``sources_deploy`` [deployer](examples/extensions/deployers/sources/sources_deploy.py): Copies the sources of all your dependencies to your output folder. [Docs](https://docs.conan.io/en/2.0/examples/extensions/deployers/sources/custom_deployer_sources.html)

--- a/examples/extensions/deployers/run_example.py
+++ b/examples/extensions/deployers/run_example.py
@@ -5,7 +5,9 @@ from test.examples_tools import run, tmp_dir
 
 with tmp_dir("sources_tmp"):
     # Move to temp dir
-    shutil.copytree("../sources", "./sources")
-    output = run("conan graph info sources/conanfile.py -c tools.build:download_source=True --deploy=sources_deploy")
+    shutil.copy("../sources/conanfile.py", "./conanfile.py")
+    shutil.copy("../sources/sources_deploy.py", "./sources_deploy.py")
+    output = run("conan graph info conanfile.py -c tools.build:download_source=True --deploy=sources_deploy")
     # Our requirements should now be in here
-    assert "zlib" in os.listdir(os.path.join("sources", "dependency_sources"))
+    dependency_folders = set(os.listdir("dependencies_sources"))
+    assert {"zlib", "mcap", "zstd", "lz4"}.issubset(dependency_folders)

--- a/examples/extensions/deployers/run_example.py
+++ b/examples/extensions/deployers/run_example.py
@@ -1,0 +1,11 @@
+import os
+import shutil
+
+from test.examples_tools import run, tmp_dir
+
+with tmp_dir("sources_tmp"):
+    # Move to temp dir
+    shutil.copytree("../sources", "./sources")
+    output = run("conan graph info sources/conanfile.py -c tools.build:download_source=True --deploy=sources_deploy")
+    # Our requirements should now be in here
+    assert "zlib" in os.listdir(os.path.join("sources", "dependency_sources"))

--- a/examples/extensions/deployers/sources/conanfile.py
+++ b/examples/extensions/deployers/sources/conanfile.py
@@ -1,0 +1,13 @@
+from conan import ConanFile
+
+
+class BasicConanfile(ConanFile):
+    name = "pkg"
+    version = "1.0"
+    description = "A basic recipe"
+
+    # The requirements method allows you to define the dependencies of your recipe
+    def requirements(self):
+        # Each call to self.requires() will add the corresponding requirement
+        # to the current list of requirements
+        self.requires("zlib/1.2.13")

--- a/examples/extensions/deployers/sources/conanfile.py
+++ b/examples/extensions/deployers/sources/conanfile.py
@@ -11,3 +11,4 @@ class BasicConanfile(ConanFile):
         # Each call to self.requires() will add the corresponding requirement
         # to the current list of requirements
         self.requires("zlib/1.2.13")
+        self.requires("mcap/0.5.0")

--- a/examples/extensions/deployers/sources/sources_deploy.py
+++ b/examples/extensions/deployers/sources/sources_deploy.py
@@ -4,4 +4,4 @@ import os
 
 def deploy(graph, output_folder):
     for name, dep in graph.root.conanfile.dependencies.items():
-        copy(graph.root.conanfile, "*", dep.folders.source_folder, os.path.join(output_folder, "dependency_sources", str(dep)))
+        copy(graph.root.conanfile, "*", dep.folders.source_folder, os.path.join(output_folder, "dependencies_sources", str(dep)))

--- a/examples/extensions/deployers/sources/sources_deploy.py
+++ b/examples/extensions/deployers/sources/sources_deploy.py
@@ -4,4 +4,4 @@ import os
 
 def deploy(graph, output_folder):
     for name, dep in graph.root.conanfile.dependencies.items():
-        copy(dep, "*", dep.folders.source_folder, os.path.join(output_folder, "dependency_sources", str(dep)))
+        copy(graph.root.conanfile, "*", dep.folders.source_folder, os.path.join(output_folder, "dependency_sources", str(dep)))

--- a/examples/extensions/deployers/sources/sources_deploy.py
+++ b/examples/extensions/deployers/sources/sources_deploy.py
@@ -1,0 +1,7 @@
+from conan.tools.files import copy
+import os
+
+
+def deploy(graph, output_folder):
+    for name, dep in graph.root.conanfile.dependencies.items():
+        copy(dep, "*", dep.folders.source_folder, os.path.join(output_folder, "dependency_sources", str(dep)))


### PR DESCRIPTION
The example just shows how to use a deployer that copies all your dependencies sources to a folder, with the help of the `tools.build:download_source=True` conf

Docs: https://github.com/conan-io/docs/pull/2946