### PR TITLE
use tool_requires in build_requirements method

### DIFF
--- a/tutorial/consuming_packages/conanfile_py/conanfile.py
+++ b/tutorial/consuming_packages/conanfile_py/conanfile.py
@@ -12,6 +12,8 @@ class CompressorRecipe(ConanFile):
         # Add base64 dependency only for Windows
         if self.settings.os == "Windows":
             self.requires("base64/0.4.0")
+
+    def build_requirements(self):
         if self.settings.os != "Windows":  # we need cmake 3.19 in other platforms
             self.tool_requires("cmake/3.19.8")
 


### PR DESCRIPTION
according to the [documentation](https://docs.conan.io/2/reference/conanfile/methods/build_requirements.html), tool_requires usage should be in build_requirements method