### PR TITLE
Changed conanfile.py namings as they were failing the build process

### DIFF
--- a/examples/tools/cmake/cmake_toolchain/extend_own_cmake_presets/conanfile.py
+++ b/examples/tools/cmake/cmake_toolchain/extend_own_cmake_presets/conanfile.py
@@ -27,7 +27,7 @@ class fooRecipe(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
-        tc.user_presets_path = 'ConanPresets.json'
+        tc.user_presets_path = 'CMakePresets.json'
         tc.generate()
 
     def build(self):

--- a/examples/tools/cmake/cmake_toolchain/extend_own_cmake_presets/run_example.py
+++ b/examples/tools/cmake/cmake_toolchain/extend_own_cmake_presets/run_example.py
@@ -16,10 +16,10 @@ if platform.system() == "Windows":
     run(f"cmake --build --preset multi-release")
     run(f"cmake --build --preset multi-debug")
 else:
-    run(f"cmake --preset release")
-    run(f"cmake --build --preset release")
-    run(f"cmake --preset debug")
-    run(f"cmake --build --preset debug")
+    run(f"cmake --preset conan-release")
+    run(f"cmake --build --preset conan-release")
+    run(f"cmake --preset conan-debug")
+    run(f"cmake --build --preset conan-debug")
 
 if platform.system() == "Windows":        
     output = run("build\\Release\\foo.exe")


### PR DESCRIPTION
Changed tc.user_presets_path = 'ConanPresets.json' to tc.user_presets_path = 'CMakePresets.json'.

I also changed "release" and "debug" names used for CMake presets to have "conan-" before their names.