### PR TITLE
Update conanfile in create_package/add_dependencies to match tutorial

### DIFF
--- a/tutorial/creating_packages/add_requires/conanfile.py
+++ b/tutorial/creating_packages/add_requires/conanfile.py
@@ -24,7 +24,7 @@ class helloRecipe(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, "11")
-        check_max_cppstd(self, "23")
+        check_max_cppstd(self, "20")
 
     def source(self):
         git = Git(self)

--- a/tutorial/creating_packages/add_requires/conanfile.py
+++ b/tutorial/creating_packages/add_requires/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 from conan.tools.scm import Git
-from conan.tools.build import check_min_cppstd
+from conan.tools.build import check_max_cppstd, check_min_cppstd
 
 
 class helloRecipe(ConanFile):
@@ -24,6 +24,7 @@ class helloRecipe(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, "11")
+        check_max_cppstd(self, "14")
 
     def source(self):
         git = Git(self)

--- a/tutorial/creating_packages/add_requires/conanfile.py
+++ b/tutorial/creating_packages/add_requires/conanfile.py
@@ -24,7 +24,7 @@ class helloRecipe(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, "11")
-        check_max_cppstd(self, "14")
+        check_max_cppstd(self, "23")
 
     def source(self):
         git = Git(self)


### PR DESCRIPTION
There was a difference between the conanfile.py from the examples2 repository and the one shown In the tutorial section creating_packages/add_dependencies_to_packages: https://docs.conan.io/2/tutorial/creating_packages/add_dependencies_to_packages.html 

The conanfile.py has been updated to reflect the version shown on the tutorial.
