### PR TITLE
Make the `simple_cmake_project` output correct size of compressed data

### DIFF
--- a/tutorial/consuming_packages/simple_cmake_project/src/main.c
+++ b/tutorial/consuming_packages/simple_cmake_project/src/main.c
@@ -24,7 +24,7 @@ int main(void) {
     deflateEnd(&defstream);
 
     printf("Uncompressed size is: %lu\n", strlen(buffer_in));
-    printf("Compressed size is: %lu\n", strlen(buffer_out));
+    printf("Compressed size is: %lu\n", defstream.total_out);
 
     printf("ZLIB VERSION: %s\n", zlibVersion());
 


### PR DESCRIPTION
Hi, nothing serious here, but it was just a bit confusing to see the size of 19 once you've done all the steps from beginner's tutorial.

Usage of ZLib-provided `total_out` instead of C-string length counting will fix it:

```
❯ ./compressor 
Uncompressed size is: 207
Compressed size is: 149

---
78 da 4d 8e 41 0e c2 30 0c 04 bf b2 f7 02 9f e8 
89 03 e2 00 1f 30 89 5b 2c 12 27 8a 53 50 7f 8f 
d5 0a 89 93 e5 f5 ac 77 c7 a2 a4 10 03 e1 72 be 
1f 93 04 56 e3 78 c0 b5 b2 e2 56 96 16 18 95 c2 
8b 66 46 26 f5 d1 30 95 86 11 a4 11 e3 30 20 f2 
9b 53 a9 99 b5 1f 40 29 95 8f e8 fc af a2 33 65 
43 2f 60 32 49 eb e6 e4 69 92 20 7e f5 7d ff 8b 
fe 64 69 bf 30 db a8 c8 5e 23 b2 3a e9 42 68 c5 
0c 35 51 f7 06 79 27 1e 8b a4 08 5b ad 73 b6 d3 
17 d8 db 4b 39 
---

ZLIB VERSION: 1.2.11
```