### PR TITLE
Add example of editable package with custom src folder layout

### DIFF
--- a/tutorial/developing_packages/editable_cmake_packages/ci_test_example.py
+++ b/tutorial/developing_packages/editable_cmake_packages/ci_test_example.py
@@ -1,0 +1,80 @@
+import platform
+import os
+
+from conan import conan_version
+
+from test.examples_tools import run, chdir, replace
+
+
+print("- Editable packages (cmake_layout with separate build folders) -")
+
+
+# FIXME: remove once 2.0-beta10 is out
+prefix_preset_name = "" if "beta9" in str(conan_version) else "conan-"
+editable_add_argument = "say/1.0" if "beta9" in str(conan_version) else "--name=say --version=1.0"
+editable_remove_argument = "say/1.0" if "beta9" in str(conan_version) else "--refs=say/1.0"
+
+run(f"conan editable add --output-folder build_say say {editable_add_argument}")
+
+# Set up the conan generators folders
+# Use the consumer to generate the ../build_say/*/generators folders
+with chdir("hello"):
+    if platform.system() == "Windows":
+        run("conan install . -s build_type=Release --output-folder ../build_hello")
+        run("conan install . -s build_type=Debug --output-folder ../build_hello")
+    else:
+        run("conan install . -s build_type=Release --output-folder ../build_hello")
+
+# Build the dependency explicitly (no need for conan-install, that was done by consumer in previous step)
+# This step could be skipped if conan install (above) included --build=editable
+with chdir("say"):
+    if platform.system() == "Windows":
+        # This step was done by hello ... run("conan install . -s build_type=Release")
+        # This step was done by hello ... run("conan install . -s build_type=Debug")
+        run(f"cmake --preset {prefix_preset_name}default")
+        run(f"cmake --build --preset {prefix_preset_name}release")
+        run(f"cmake --build --preset {prefix_preset_name}debug")
+    else:
+        # This step was done by hello ... run("conan install . -s build_type=Release")
+        run(f"cmake --preset {prefix_preset_name}release")
+        run(f"cmake --build --preset {prefix_preset_name}release")
+
+# Build the consumer
+with chdir("hello"):
+    if platform.system() == "Windows":
+        run(f"cmake --preset {prefix_preset_name}default")
+        run(f"cmake --build --preset {prefix_preset_name}release")
+        run(f"cmake --build --preset {prefix_preset_name}debug")
+        cmd_out = run("../build_hello/Release/hello.exe")
+        assert "say/1.0: Hello World Release!" in cmd_out
+        cmd_out = run("../build_hello/Debug/hello.exe")
+        assert "say/1.0: Hello World Debug!" in cmd_out
+    else:
+        run(f"cmake --preset {prefix_preset_name}release")
+        run(f"cmake --build --preset {prefix_preset_name}release")
+        cmd_out = run("../build_hello/Release/hello")
+        assert "say/1.0: Hello World Release!" in cmd_out
+
+# Edit 'say' source code
+with chdir("say"):
+    replace(os.path.join("thelib/src", "say.cpp"), "Hello World", "Bye World")
+    if platform.system() == "Windows":        
+        run(f"cmake --build --preset {prefix_preset_name}release")
+        run(f"cmake --build --preset {prefix_preset_name}debug")
+    else:
+        run(f"cmake --build --preset {prefix_preset_name}release")
+
+with chdir("hello"):
+    if platform.system() == "Windows":        
+        run(f"cmake --build --preset {prefix_preset_name}release")
+        run(f"cmake --build --preset {prefix_preset_name}debug")
+        cmd_out = run("../build_hello/Release/hello.exe")
+        assert "say/1.0: Bye World Release!" in cmd_out
+        cmd_out = run("../build_hello/Debug/hello.exe")
+        assert "say/1.0: Bye World Debug!" in cmd_out
+    else:
+        run(f"cmake --build --preset {prefix_preset_name}release")
+        cmd_out = run("../build_hello/Release/hello")
+        assert "say/1.0: Bye World Release!" in cmd_out
+
+run(f"conan editable remove {editable_remove_argument}")

--- a/tutorial/developing_packages/editable_cmake_packages/hello/CMakeLists.txt
+++ b/tutorial/developing_packages/editable_cmake_packages/hello/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(Hello)
+
+find_package(say REQUIRED)
+
+add_executable(hello src/hello.cpp)
+target_link_libraries(hello say::say)

--- a/tutorial/developing_packages/editable_cmake_packages/hello/conanfile.py
+++ b/tutorial/developing_packages/editable_cmake_packages/hello/conanfile.py
@@ -1,0 +1,23 @@
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class HelloConan(ConanFile):
+    name = "hello"
+    version = "1.0"
+
+    settings = "os", "compiler", "build_type", "arch"
+
+    generators = "CMakeToolchain", "CMakeDeps"
+    requires = "say/1.0"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def configure(self):
+        self.options["say"].something_custom = True
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()

--- a/tutorial/developing_packages/editable_cmake_packages/hello/src/hello.cpp
+++ b/tutorial/developing_packages/editable_cmake_packages/hello/src/hello.cpp
@@ -1,0 +1,5 @@
+#include "say.h"
+
+int main() {
+    say();
+}

--- a/tutorial/developing_packages/editable_cmake_packages/say/CMakeLists.txt
+++ b/tutorial/developing_packages/editable_cmake_packages/say/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.15)
+project(say CXX)
+
+add_subdirectory(thelib/src)

--- a/tutorial/developing_packages/editable_cmake_packages/say/conanfile.py
+++ b/tutorial/developing_packages/editable_cmake_packages/say/conanfile.py
@@ -1,0 +1,46 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+
+
+class SayConan(ConanFile):
+    name = "say"
+    version = "1.0"
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False], "something_custom": [True, False]}
+    default_options = {"shared": False, "fPIC": True, "something_custom": False}
+
+    # Sources are located in the same place as this recipe, copy them to the recipe
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def validate(self):
+        # ensure the consumer's options affect this dependency
+        if not self.options.something_custom:
+            raise ConanInvalidConfiguration("The consumer should set something_custom=True")
+
+    def layout(self):
+        cmake_layout(self)
+
+        self.cpp.source.includedirs = ["thelib/src"]
+        self.cpp.build.libdirs = ["thelib/src"]
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["say"]

--- a/tutorial/developing_packages/editable_cmake_packages/say/thelib/src/CMakeLists.txt
+++ b/tutorial/developing_packages/editable_cmake_packages/say/thelib/src/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(say say.cpp)
+# target_include_directories(say PUBLIC include)
+
+# set_target_properties(say PROPERTIES PUBLIC_HEADER "include/say.h")
+install(TARGETS say)
+install(FILES say.h DESTINATION "include/say")

--- a/tutorial/developing_packages/editable_cmake_packages/say/thelib/src/say.cpp
+++ b/tutorial/developing_packages/editable_cmake_packages/say/thelib/src/say.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include "say.h"
+
+void say(){
+    #ifdef NDEBUG
+    std::cout << "say/1.0: Hello World Release!\n";
+    #else
+    std::cout << "say/1.0: Hello World Debug!\n";
+    #endif
+}

--- a/tutorial/developing_packages/editable_cmake_packages/say/thelib/src/say.h
+++ b/tutorial/developing_packages/editable_cmake_packages/say/thelib/src/say.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef WIN32
+  #define say_EXPORT __declspec(dllexport)
+#else
+  #define say_EXPORT
+#endif
+
+say_EXPORT void say();


### PR DESCRIPTION
Please consider adding a more complicated example,
where the user can use cmake_layout() AND add to the layout() function to support editable, where the source is in an unusual layout.

Also, this example demonstrates how to use the consumer to initialise the editable dependency build environment, which is required  when the consumer may apply a complex set of options to the dependency.
