### PR TITLE
Add `self.options.rm_safe("fPIC")` on `configure_options_settings`

### DIFF
--- a/tutorial/creating_packages/configure_options_settings/conanfile.py
+++ b/tutorial/creating_packages/configure_options_settings/conanfile.py
@@ -38,7 +38,7 @@ class helloRecipe(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
     def source(self):
         git = Git(self)


### PR DESCRIPTION
This change prevent the error on Windows with `-o shared=True`
Related with: https://github.com/conan-io/conan/issues/16881

```
ERROR: hello/1.0: Error in configure() method, line 41
        del self.options.fPIC
        ConanException: option 'fPIC' doesn't exist
Possible options are ['shared', 'with_fmt']
```