### PR TITLE
Fix string quoting in conan commands of ci tutorial

### DIFF
--- a/ci/game/project_setup.py
+++ b/ci/game/project_setup.py
@@ -61,7 +61,7 @@ def project_setup():
     # and 2 consuming applications, everything with version ranges
     print("- Setup the project initial state -")
     run('conan remove "*" -c')  # Make sure no packages from last run
-    run("conan remote remove *")
+    run('conan remote remove "*"')
     run("conan profile detect -f")
     print("Cleaning server repos contents")
     for repo in (PRODUCTS, DEVELOP, PACKAGES):
@@ -84,10 +84,10 @@ def project_setup():
     run(f'conan upload "*" -r={DEVELOP} -c')
     run('conan remove "*" -c')  # Make sure no packages from last run
 
-    run('conan remote disable *')
+    run('conan remote disable "*"')
     run(f'conan remote enable {DEVELOP}')
     print(run("conan remote list"))
-    print(run("conan list *"))
+    print(run('conan list "*"'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```
Running: conan remote remove *
Traceback (most recent call last):
  File "/home/amachado/stuff/examples2/ci/game/project_setup.py", line 94, in <module>
    project_setup()
  File "/home/amachado/stuff/examples2/ci/game/project_setup.py", line 64, in project_setup
    run("conan remote remove *")
  File "/home/amachado/stuff/examples2/ci/game/project_setup.py", line 33, in run
    raise Exception("Failed cmd: {}\n{}".format(cmd, output))
Exception: Failed cmd: conan remote remove *
usage: conan remote [-h] [-v [V]] [-cc CORE_CONF] {remove} ...
conan remote: error: unrecognized arguments: engine game graphics mapviewer mathlib project_setup.py run_example.py
ERROR: Exiting with code: 2
```
The error occurs because the `*` wildcard is being expanded by the shell to include all files and directories in the current directory, which is not what the conan remote disable command expects. 
To pass the `*` as a literal argument to the conan command without being expanded by the shell, we should use quotes around the `*`.
This way, the * is passed as a literal argument to the conan command, and it will not be expanded by the shell.