### PR TITLE
fix tutorial create build_method

### DIFF
--- a/tutorial/creating_packages/build_method/ci_test_example.py
+++ b/tutorial/creating_packages/build_method/ci_test_example.py
@@ -3,10 +3,10 @@ from test.examples_tools import run
 
 print("- Building and running tests in the build() method -")
 
-out = run(f"conan create . --build=missing")
+out = run(f"conan create . --build=missing --build=hello*")
 
 assert "Running 1 test from 1 test suite." in out
 
-out = run(f"conan create . --build=missing -c tools.build:skip_test=True")
+out = run(f"conan create . --build=missing --build=hello* -c tools.build:skip_test=True")
 
 assert "Running 1 test from 1 test suite." not in out


### PR DESCRIPTION
Fix broken CI

For some reason it seems that it is caching more the "hello" package, so if it doesn't build, it doesn't run the gtest tests and fails.
It broke for the same commit in 2 different nightly builds, so maybe something else changed in the CI?