### PR TITLE
Add Yocto example: Consume mosquitto via meta-conan

### DIFF
--- a/examples/cross_build/README.md
+++ b/examples/cross_build/README.md
@@ -8,3 +8,7 @@
 ### [Use Android NDK to cross-build](android/ndk_basic)
 
 - Learn how to cross-build packages for Android. [Docs](https://docs.conan.io/2/examples/cross_build/android.html)
+
+### [Use Conan to install Yocto dependencies](yocto)
+
+- Use meta-conan to install mosquitto as Yocto dependency. [Docs](https://docs.conan.io/2/integrations/yocto.html)

--- a/examples/cross_build/yocto/ci_test_example.sh
+++ b/examples/cross_build/yocto/ci_test_example.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+yocto_release=scarthgap
+
+echo "- Yocto - Consume Mosquitto from Conan -"
+
+rm -rf poky
+
+echo "INFO: Cloning Yocto layers"
+git clone --branch ${yocto_release} --depth 1 https://git.yoctoproject.org/poky.git poky
+git clone --branch ${yocto_release} --depth 1 https://github.com/openembedded/meta-openembedded.git poky/meta-openembedded
+git clone --branch conan2/${yocto_release} https://github.com/conan-io/meta-conan.git poky/meta-conan
+
+mkdir -p poky/meta-conan/recipes-example
+cp conan-mosquitto_2.0.18.bb poky/meta-conan/recipes-example/conan-mosquitto_2.0.18.bb
+
+cd poky
+source oe-init-build-env
+
+echo "INFO: Adding layers"
+bitbake-layers add-layer ../meta-openembedded/meta-oe
+bitbake-layers add-layer ../meta-openembedded/meta-python
+bitbake-layers add-layer ../meta-conan
+
+echo "INFO: Present layers"
+bitbake-layers show-layers
+
+
+echo 'IMAGE_INSTALL:append = " conan-mosquitto"' >> conf/local.conf
+
+echo "INFO: Fetching mosquitto"
+bitbake -v -c fetch conan-mosquitto
+
+if [ -n "${CONAN_YOCTO_BUILD_MOSQUITTO}" ]; then
+    echo "INFO: Building mosquitto"
+    bitbake -v -c configure conan-mosquitto
+    bitbake -v -c compile conan-mosquitto
+    bitbake -v -c package conan-mosquitto    
+else:
+    echo "INFO: Skipping mosquitto build due large time. Set CONAN_YOCTO_BUILD_MOSQUITTO to build mosquitto."
+fi
+
+if [ -n "${CONAN_YOCTO_BUILD_IMAGE}" ]; then
+    echo "INFO: Building core-image-minimal"
+    bitbake -v core-image-minimal
+else:
+    echo "INFO: Skipping image build due large time. Set CONAN_YOCTO_BUILD_IMAGE to build image."
+fi

--- a/examples/cross_build/yocto/conan-mosquitto_2.0.18.bb
+++ b/examples/cross_build/yocto/conan-mosquitto_2.0.18.bb
@@ -1,0 +1,5 @@
+inherit conan
+
+DESCRIPTION = "An open source MQTT broker"
+LICENSE = "EPL-1.0"
+CONAN_PKG = "mosquitto/2.0.18"


### PR DESCRIPTION
Related to https://github.com/conan-io/docs/pull/4002

This example follows the section `Deploying an application to a Yocto image` in the PR documentation.

Building Yocto takes several hours, so I reduced this execution to stop after fetching the mosquitto layer, so we can validate it at least. 

