### PR TITLE
[hotfix] Extension example for clean could not import Conan API search

### DIFF
--- a/examples/extensions/commands/ci_test_example.py
+++ b/examples/extensions/commands/ci_test_example.py
@@ -1,7 +1,8 @@
 import os
+import warnings
 
 from test.examples_tools import run, tmp_dir
-
+from conan import conan_version
 
 non_deterministic_conanfile = """\
 from datetime import datetime
@@ -54,11 +55,14 @@ with tmp_dir("clean_other"):
         f.write(non_deterministic_conanfile.format(name="clean_other", comment="# Changing RREV"))
     run("conan create .")  # different RREV (this is the latest one)
 
-# 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
-output = run("conan clean --force")
-assert "Removed package revision: clean_hello/1.0#" in output  # removing earlier PREV from clean_hello
-assert "Removed recipe revision: clean_other/1.0#" in output  # removing earlier RREV from clean_other
-# Now, it should have removed nothing
-output = run("conan clean --force")
-assert "Removed recipe revision: clean_other/1.0#" not in output
-assert "Removed package revision: clean_hello/1.0#" not in output
+if conan_version >= "2.21.0-dev":
+    # 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
+    output = run("conan clean --force")
+    assert "Removed package revision: clean_hello/1.0#" in output  # removing earlier PREV from clean_hello
+    assert "Removed recipe revision: clean_other/1.0#" in output  # removing earlier RREV from clean_other
+    # Now, it should have removed nothing
+    output = run("conan clean --force")
+    assert "Removed recipe revision: clean_other/1.0#" not in output
+    assert "Removed package revision: clean_hello/1.0#" not in output
+else:
+    warnings.warn("Skipping 'conan clean' test because it requires Conan 2.21 due new API list.")

--- a/examples/extensions/commands/ci_test_example.py
+++ b/examples/extensions/commands/ci_test_example.py
@@ -59,8 +59,10 @@ with tmp_dir("clean_other"):
 if conan_version >= "2.21.0-dev":
     run("conan list '*/*#*:*#*' --format=json --out-file=list.json")
     all_packages = json.load(open("list.json"))
+    print(f"BEFORE - ALL PACKAGES: {all_packages}")
     run("conan list '*/*#latest:*#latest' --format=json --out-file=list.json")
     latest_packages = json.load(open("list.json"))
+    print(f"BEFORE - LATEST PACKAGES: {latest_packages}")
     assert all_packages != latest_packages, "Make sure we have some old revisions to clean"
     # 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
     output = run("conan clean --force")
@@ -73,6 +75,7 @@ if conan_version >= "2.21.0-dev":
     # Make sure latest revisions are still there
     run("conan list '*/*#*:*#*' --format=json --out-file=list.json")
     listed_after = json.load(open("list.json"))
+    print(f"AFTER - LISTED PACKAGES: {listed_after}")
     assert latest_packages == listed_after
 else:
     warnings.warn("Skipping 'conan clean' test because it requires Conan 2.21 due new API list.")

--- a/examples/extensions/commands/ci_test_example.py
+++ b/examples/extensions/commands/ci_test_example.py
@@ -57,10 +57,10 @@ with tmp_dir("clean_other"):
     run("conan create .")  # different RREV (this is the latest one)
 
 if conan_version >= "2.21.0-dev":
-    run("conan list '*/*#*:*#*' --format=json --out-file=list.json")
-    all_packages = json.load(open("list.json"))
-    run("conan list '*/*#latest:*#latest' --format=json --out-file=list.json")
-    latest_packages = json.load(open("list.json"))
+    output = run("conan list '*/*#*:*#*' --format=json ")
+    all_packages = json.loads("\n".join(output.splitlines()[1:]))
+    output = run("conan list '*/*#latest:*#latest' --format=json")
+    latest_packages = json.loads("\n".join(output.splitlines()[1:]))
     assert all_packages != latest_packages, "Make sure we have some old revisions to clean"
     # 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
     output = run("conan clean --force")
@@ -71,8 +71,8 @@ if conan_version >= "2.21.0-dev":
     assert "Removed recipe revision: clean_other/1.0#" not in output
     assert "Removed package revision: clean_hello/1.0#" not in output
     # Make sure latest revisions are still there
-    run("conan list '*/*#*:*#*' --format=json --out-file=list.json")
-    listed_after = json.load(open("list.json"))
+    output = run("conan list '*/*#*:*#*' --format=json")
+    listed_after = json.loads("\n".join(output.splitlines()[1:]))
     assert json.dumps(latest_packages, sort_keys=True) == json.dumps(listed_after, sort_keys=True)
 else:
     warnings.warn("Skipping 'conan clean' test because it requires Conan 2.21 due new API list.")

--- a/examples/extensions/commands/ci_test_example.py
+++ b/examples/extensions/commands/ci_test_example.py
@@ -73,6 +73,6 @@ if conan_version >= "2.21.0-dev":
     # Make sure latest revisions are still there
     output = run("conan list '*/*#*:*#*' --format=json")
     listed_after = json.loads("\n".join(output.splitlines()[1:]))
-    assert json.dumps(latest_packages, sort_keys=True) == json.dumps(listed_after, sort_keys=True)
+    assert latest_packages == listed_after
 else:
     warnings.warn("Skipping 'conan clean' test because it requires Conan 2.21 due new API list.")

--- a/examples/extensions/commands/ci_test_example.py
+++ b/examples/extensions/commands/ci_test_example.py
@@ -61,7 +61,8 @@ if conan_version >= "2.21.0-dev":
     all_packages = json.loads("\n".join(output.splitlines()[1:]))
     output = run("conan list '*/*#latest:*#latest' --format=json")
     latest_packages = json.loads("\n".join(output.splitlines()[1:]))
-    assert all_packages != latest_packages, "Make sure we have some old revisions to clean"
+    if all_packages == latest_packages:
+        warnings.warn("Skipping 'conan clean' test because there are no old revisions to clean.")
     # 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
     output = run("conan clean --force")
     assert "Removed package revision: clean_hello/1.0#" in output  # removing earlier PREV from clean_hello

--- a/examples/extensions/commands/ci_test_example.py
+++ b/examples/extensions/commands/ci_test_example.py
@@ -59,10 +59,8 @@ with tmp_dir("clean_other"):
 if conan_version >= "2.21.0-dev":
     run("conan list '*/*#*:*#*' --format=json --out-file=list.json")
     all_packages = json.load(open("list.json"))
-    print(f"BEFORE - ALL PACKAGES: {all_packages}")
     run("conan list '*/*#latest:*#latest' --format=json --out-file=list.json")
     latest_packages = json.load(open("list.json"))
-    print(f"BEFORE - LATEST PACKAGES: {latest_packages}")
     assert all_packages != latest_packages, "Make sure we have some old revisions to clean"
     # 3. Run "conan clean" command: Cleaning all the non-latest RREVs (and its packages) and PREVs
     output = run("conan clean --force")
@@ -75,7 +73,6 @@ if conan_version >= "2.21.0-dev":
     # Make sure latest revisions are still there
     run("conan list '*/*#*:*#*' --format=json --out-file=list.json")
     listed_after = json.load(open("list.json"))
-    print(f"AFTER - LISTED PACKAGES: {listed_after}")
-    assert latest_packages == listed_after
+    assert json.dumps(latest_packages, sort_keys=True) == json.dumps(listed_after, sort_keys=True)
 else:
     warnings.warn("Skipping 'conan clean' test because it requires Conan 2.21 due new API list.")

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -1,5 +1,5 @@
 from conan.api.conan_api import ConanAPI
-from conan.internal.conan_app import ConanBasicApp
+from conan.api.model import PackagesList, ListPattern
 from conan.api.input import UserInput
 from conan.api.output import ConanOutput, Color
 from conan.cli.command import OnceArgument, conan_command
@@ -7,25 +7,6 @@ from conan.cli.command import OnceArgument, conan_command
 recipe_color = Color.BRIGHT_BLUE
 removed_color = Color.BRIGHT_YELLOW
 
-def _search_recipes(app, query: str, remote=None):
-    """"
-    Searches recipes in local cache or in a remote.
-    Extracted from conan/api/subapi/list.py
-    """
-    only_none_user_channel = False
-    if query and query.endswith("@"):
-        only_none_user_channel = True
-        query = query[:-1]
-
-    if remote:
-        refs = app.remote_manager.search_recipes(remote, query)
-    else:
-        refs = app.cache.search_recipes(query)
-    ret = []
-    for r in refs:
-        if not only_none_user_channel or (r.user is None and r.channel is None):
-            ret.append(r)
-    return sorted(ret)
 
 @conan_command(group="Custom commands")
 def clean(conan_api: ConanAPI, parser, *args):
@@ -47,27 +28,24 @@ def clean(conan_api: ConanAPI, parser, *args):
     remote = conan_api.remotes.get(args.remote) if args.remote else None
     output_remote = remote or "Local cache"
 
-    # Getting all the recipes
-    conan_app = ConanBasicApp(conan_api)
-    recipes = _search_recipes(conan_app, "*/*", remote=remote)
-    if recipes and not confirmation("Do you want to remove all the recipes revisions and their packages ones, "
+    # Get all recipes and packages, where recipe revision is not the latest
+    pkg_list = conan_api.list.select(ListPattern("*/*#!latest:*#*", rrev=None, prev=None), remote=remote)
+    if pkg_list and not confirmation("Do you want to remove all the recipes revisions and their packages ones, "
                                     "except the latest package revision from the latest recipe one?"):
+        out.writeln("Aborted")
         return
-    for recipe in recipes:
-        out.writeln(f"{str(recipe)}", fg=recipe_color)
-        all_rrevs = conan_api.list.recipe_revisions(recipe, remote=remote)
-        latest_rrev = all_rrevs[0] if all_rrevs else None
-        for rrev in all_rrevs:
-            if rrev != latest_rrev:
-                conan_api.remove.recipe(rrev, remote=remote)
-                out.writeln(f"Removed recipe revision: {rrev.repr_notime()} "
-                            f"and all its package revisions [{output_remote}]", fg=removed_color)
-            else:
-                packages = conan_api.list.packages_configurations(rrev, remote=remote)
-                for package_ref in packages:
-                    all_prevs = conan_api.list.package_revisions(package_ref, remote=remote)
-                    latest_prev = all_prevs[0] if all_prevs else None
-                    for prev in all_prevs:
-                       if prev != latest_prev:
-                           conan_api.remove.package(prev, remote=remote)
-                           out.writeln(f"Removed package revision: {prev.repr_notime()} [{output_remote}]", fg=removed_color)
+
+    # Remove all packages for old recipe revisions
+    for recipe_ref, recipe_bundle in pkg_list.refs().items():
+        conan_api.remove.recipe(recipe_ref, remote=remote)
+        out.writeln(f"Removed recipe revision: {recipe_ref.repr_notime()} "
+                    f"and all its package revisions [{output_remote}]", fg=removed_color)
+
+    # Get all package revisions from the latest recipe revision, except the latest package revision
+    pkg_list = conan_api.list.select(ListPattern("*/*#latest:*#!latest", rrev=None, prev=None), remote=remote)
+    for recipe_ref, recipe_bundle in pkg_list.refs().items():
+        pkg_list = PackagesList.prefs(recipe_ref, recipe_bundle)
+        for pkg_ref in pkg_list.keys():
+            # Remove all package revisions except the latest one
+            conan_api.remove.package(pkg_ref, remote=remote)
+            out.writeln(f"Removed package revision: {pkg_ref.repr_notime()} [{output_remote}]", fg=removed_color)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -29,20 +29,20 @@ def clean(conan_api: ConanAPI, parser, *args):
     output_remote = remote or "Local cache"
 
     # Get all recipes and packages, where recipe revision is not the latest
-    pkg_list = conan_api.list.select(ListPattern("*/*#!latest:*#*", rrev=None, prev=None), remote=remote)
+    pkg_list = conan_api.list.select(ListPattern("*/*#!latest", rrev=None, prev=None), remote=remote)
     if pkg_list and not confirmation("Do you want to remove all the recipes revisions and their packages ones, "
                                     "except the latest package revision from the latest recipe one?"):
         out.writeln("Aborted")
         return
 
     # Remove all packages for old recipe revisions
-    for recipe_ref, recipe_bundle in pkg_list.refs().items():
+    for recipe_ref in pkg_list.refs().keys():
         conan_api.remove.recipe(recipe_ref, remote=remote)
         out.writeln(f"Removed recipe revision: {recipe_ref.repr_notime()} "
                     f"and all its package revisions [{output_remote}]", fg=removed_color)
 
     # Get all package revisions from the latest recipe revision, except the latest package revision
-    pkg_list = conan_api.list.select(ListPattern("*/*#latest:*#!latest", rrev=None, prev=None), remote=remote)
+    pkg_list = conan_api.list.select(ListPattern("*/*:*#!latest", rrev=None, prev=None), remote=remote)
     for recipe_ref, recipe_bundle in pkg_list.refs().items():
         pkg_list = PackagesList.prefs(recipe_ref, recipe_bundle)
         for pkg_ref in pkg_list.keys():

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -53,6 +53,6 @@ def clean(conan_api: ConanAPI, parser, *args):
                             out.writeln(f"Removed package revision: {pref.repr_notime()} [{output_remote}]", fg=removed_color)
             else:
                 # Otherwise, remove all outdated recipe revisions and their packages
-                conan_api.remove.recipe(pkg_ref, remote=remote)
-                out.writeln(f"Removed recipe revision: {pkg_ref.repr_notime()} "
+                conan_api.remove.recipe(pref, remote=remote)
+                out.writeln(f"Removed recipe revision: {pref.repr_notime()} "
                             f"and all its package revisions [{output_remote}]", fg=removed_color)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -37,17 +37,17 @@ def clean(conan_api: ConanAPI, parser, *args):
 
     # Split the package list into recipe bundles based on their recipe reference
     for ref_bundle in pkg_list.split():
-        latest = max(ref_bundle.refs(), key=lambda r: r.revision)
+        latest = max(ref_bundle.items(), key=lambda item: item[0])[0]
         out.writeln(f"Keeping recipe revision: {latest.repr_notime()} "
                     f"and its latest package revisions [{output_remote}]", fg=recipe_color)
-        for pkg_ref, pkg_bundle in ref_bundle.refs().items():
+        for pkg_ref, pkg_bundle in ref_bundle.items():
             # For the latest recipe revision, keep the latest package revision only
             if latest == pkg_ref:
-                prefs = PackagesList.prefs(latest, pkg_bundle)
-                if prefs:
-                    latest_pref = max(prefs.keys(), key=lambda p: p.revision)
+                if pkg_bundle:
+                    # Use PkgReference.timestamp to get the latest package revision. No __lt__ defined
+                    latest_pref = max(pkg_bundle.keys(), key=lambda p: p.timestamp)
                     out.writeln(f"Keeping package revision: {latest_pref.repr_notime()} [{output_remote}]", fg=recipe_color)
-                    for pref in prefs.keys():
+                    for pref in pkg_bundle.keys():
                         if latest_pref != pref:
                             conan_api.remove.package(pref, remote=remote)
                             out.writeln(f"Removed package revision: {pref.repr_notime()} [{output_remote}]", fg=removed_color)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -36,18 +36,18 @@ def clean(conan_api: ConanAPI, parser, *args):
         return
 
     # Split the package list into recipe bundles based on their recipe reference
-    for ref_bundle in pkg_list.split():
-        latest = max(ref_bundle.items(), key=lambda item: item[0])[0]
+    for sub_pkg_list in pkg_list.split():
+        latest = max(sub_pkg_list.items(), key=lambda item: item[0])[0]
         out.writeln(f"Keeping recipe revision: {latest.repr_notime()} "
                     f"and its latest package revisions [{output_remote}]", fg=recipe_color)
-        for pkg_ref, pkg_bundle in ref_bundle.items():
+        for pref, packages in sub_pkg_list.items():
             # For the latest recipe revision, keep the latest package revision only
-            if latest == pkg_ref:
-                if pkg_bundle:
+            if latest == pref:
+                if packages:
                     # Use PkgReference.timestamp to get the latest package revision. No __lt__ defined
-                    latest_pref = max(pkg_bundle.keys(), key=lambda p: p.timestamp)
+                    latest_pref = max(packages.keys(), key=lambda p: p.timestamp)
                     out.writeln(f"Keeping package revision: {latest_pref.repr_notime()} [{output_remote}]", fg=recipe_color)
-                    for pref in pkg_bundle.keys():
+                    for pref in packages:
                         if latest_pref != pref:
                             conan_api.remove.package(pref, remote=remote)
                             out.writeln(f"Removed package revision: {pref.repr_notime()} [{output_remote}]", fg=removed_color)

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -1,4 +1,5 @@
 from conan.api.conan_api import ConanAPI
+from conan.internal.conan_app import ConanBasicApp
 from conan.api.input import UserInput
 from conan.api.output import ConanOutput, Color
 from conan.cli.command import OnceArgument, conan_command
@@ -47,7 +48,8 @@ def clean(conan_api: ConanAPI, parser, *args):
     output_remote = remote or "Local cache"
 
     # Getting all the recipes
-    recipes = _search_recipes(conan_api.app, "*/*", remote=remote)
+    conan_app - ConanBasicApp(conan_api)
+    recipes = _search_recipes(conan_app, "*/*", remote=remote)
     if recipes and not confirmation("Do you want to remove all the recipes revisions and their packages ones, "
                                     "except the latest package revision from the latest recipe one?"):
         return

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -6,6 +6,7 @@ from conan.cli.command import OnceArgument, conan_command
 recipe_color = Color.BRIGHT_BLUE
 removed_color = Color.BRIGHT_YELLOW
 
+# TRIGGER CI
 
 @conan_command(group="Custom commands")
 def clean(conan_api: ConanAPI, parser, *args):

--- a/examples/extensions/commands/clean/cmd_clean.py
+++ b/examples/extensions/commands/clean/cmd_clean.py
@@ -48,7 +48,7 @@ def clean(conan_api: ConanAPI, parser, *args):
     output_remote = remote or "Local cache"
 
     # Getting all the recipes
-    conan_app - ConanBasicApp(conan_api)
+    conan_app = ConanBasicApp(conan_api)
     recipes = _search_recipes(conan_app, "*/*", remote=remote)
     if recipes and not confirmation("Do you want to remove all the recipes revisions and their packages ones, "
                                     "except the latest package revision from the latest recipe one?"):


### PR DESCRIPTION
When pushing the PR #192 , the following error occurred in the CI:

```
clean_other/1.0: Package folder /Users/jenkins/workspace/Examples2.0_PR-192/c226/cbe2/.conan/p/b/clean3acc120868975/p

Elapsed time: 0.17 seconds

Running: conan clean --force

ERROR: Traceback (most recent call last):

  File "/Users/jenkins/workspace/Examples2.0_PR-192/c226/conanenv/src/conan/conan/cli/cli.py", line 308, in main

    cli.run(args)

  File "/Users/jenkins/workspace/Examples2.0_PR-192/c226/conanenv/src/conan/conan/cli/cli.py", line 193, in run

    command.run(self._conan_api, args[0][1:])

  File "/Users/jenkins/workspace/Examples2.0_PR-192/c226/conanenv/src/conan/conan/cli/command.py", line 183, in run

    info = self._method(conan_api, parser, *args)

  File "/Users/jenkins/workspace/Examples2.0_PR-192/c226/cbe2/.conan/extensions/commands/cmd_clean.py", line 31, in clean

    recipes = conan_api.search.recipes("*/*", remote=remote)

AttributeError: 'ConanAPI' object has no attribute 'search'
```

It seems be affected by https://github.com/conan-io/conan/pull/18726 