### PR TITLE
[infrastructure] Disable tensorflow example always

### DIFF
--- a/.github/run_ci_tests.py
+++ b/.github/run_ci_tests.py
@@ -118,12 +118,11 @@ def filter_examples_by_dirs(examples, affected_dirs) -> list:
 
     return sorted(set(filtered))
 
-def filter_exclusions(examples, is_pr) -> list:
+def filter_exclusions(examples) -> list:
     """
     FIXME: Filter out broken examples after GitHub Actions migration
 
     :param examples: list of example file paths
-    :param is_pr: bool - whether this is a pull request
     :returns: filtered list of example file paths
     """
     filtered = []
@@ -135,7 +134,7 @@ def filter_exclusions(examples, is_pr) -> list:
             continue
 
         # FIXME: Filter out tensorflow examples in PRs
-        if is_pr and "tensorflow" in example:
+        if "tensorflow" in example:
             continue
 
         filtered.append(example)
@@ -205,7 +204,7 @@ def main():
             print(example)
 
     # FIXME: Filter out some non-working examples in GitHub Actions
-    examples = filter_exclusions(examples, is_pr)
+    examples = filter_exclusions(examples)
 
     print("\nExamples to run:")
     for example in examples:


### PR DESCRIPTION
Hello!

Currently, the main branch is broken on the CI: https://github.com/conan-io/examples2/actions/runs/19485398759

The main cause is that the TensorFlow example is still not ported to the new CI (yet), but it is always running when the build is not a PR:

- https://github.com/conan-io/examples2/actions/runs/19485398759/job/55766501952#step:8:13096
- https://github.com/conan-io/examples2/actions/runs/19485398759/job/55766501943#step:8:38

As a palliative fix, this PR disables its build, so it can pass all tests without errors.

The validation of these changes can be found at: https://github.com/uilianries/conan-examples2/actions/runs/19493401601