### PR TITLE
[fix] Update URL for ARM toolchain download

### DIFF
--- a/examples/cross_build/toolchain_packages/toolchain/conanfile.py
+++ b/examples/cross_build/toolchain_packages/toolchain/conanfile.py
@@ -52,12 +52,8 @@ class ArmToolchainPackage(ConanFile):
 
     def build(self):
         toolchain, sha = self._get_toolchain(self.settings_target.arch)
-        # INFO: ARM server does not like default Conan user-agent. It returns a frontpage HTML instead of the tarball.
-        headers={"User-Agent": "Wget/1.20.3 (linux-gnu)", "Accept": "*/*"}
-        get(self, f"https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-{toolchain}.tar.xz",
-            headers=headers,
-            sha256=sha,
-            strip_root=True)
+        get(self, f"https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-{toolchain}.tar.xz",
+            sha256=sha, strip_root=True)            
 
     def package(self):
         toolchain, _ = self._get_toolchain(self.settings_target.arch)


### PR DESCRIPTION
Hello!

The CI on the main branch failed to download the ARM Toolchain: https://github.com/conan-io/examples2/actions/runs/19700163368/job/56434239488#step:9:2302

The URL `https://developer.arm.com/-/media` is actually a frontend that resolves to a URL where the media is available. The current mismatch is actually an HTML page content being downloaded instead of the media. That page is a challenge for bots and unknown HTTP agents.

The ARM toolchain server dislikes when using `"User-Agent": "Conan/2.23.0 (Linux 6.8.0-87-generic; Python 3.12.4; x86_64)"`. However, when using a known engine like WGet, it provides the expected media content. 

This PR replaces the current URL to use the final media URL listed on the Azure server. We have evidence that more projects are using the same approach on GitHub. 