### PR TITLE
Fix flaky CI in editable components test by forcing clean build

### DIFF
--- a/examples/conanfile/layout/editable_components/ci_test_example.py
+++ b/examples/conanfile/layout/editable_components/ci_test_example.py
@@ -22,12 +22,13 @@ assert cmd_out.count("bye: Release!") == 1
 
 # Do a modification to one component, to verify it is used correctly
 replace(os.path.join("greetings", "src", "bye.cpp"), "bye:", "adios:")
-run("conan build greetings")
 
 # Force a clean build for the editable package to avoid timestamp issues
 greetings_build_path = os.path.join("greetings", "build")
 if os.path.exists(greetings_build_path):
     shutil.rmtree(greetings_build_path)
+
+run("conan build greetings")
 
 # Clean app build to ensure it uses the updated library
 app_build_path = os.path.join("app", "build")


### PR DESCRIPTION
The test was failing on macOS because the script runs so fast that the build system sometimes didn't detect the file modification (timestamp issue) and skipped the recompilation.
This forces a fresh compile and ensures the code changes are always picked up.

The fail: https://github.com/conan-io/examples2/actions/runs/20012947981