### PR TITLE
Fix CI to only run examples in directly affected directories

### DIFF
--- a/examples/libraries/README.md
+++ b/examples/libraries/README.md
@@ -9,5 +9,3 @@
 ### [Using libcurl to download an image and stb to read it](libcurl/download_image)
 
 ### [Using libcurl to download an image and stb to read it (color version with fmt)](libcurl/ascii_art_color)
-
-### remove after testing that this does not trigger all libraries tests in ci

--- a/examples/libraries/imgui/introduction/README.md
+++ b/examples/libraries/imgui/introduction/README.md
@@ -4,5 +4,3 @@
 
 ## Walkthough
 This example has a [blog post](https://blog.conan.io/2019/06/26/An-introduction-to-the-Dear-ImGui-library.html).
-
-# remove after checking that this one triggers


### PR DESCRIPTION
Pprevents running unrelated examples when modifying files in parent directories that don't contain test files directly (e.g., editing examples/libraries/README.md no longer triggers all library examples).

Fixes a case like https://github.com/conan-io/examples2/pull/213 that is running all examples under libraries after modifying the README in that folder.