### PR TITLE
test libtorch build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          update-environment: false
 
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1.14

--- a/examples/libraries/libtorch/regression/ci_test_example.py
+++ b/examples/libraries/libtorch/regression/ci_test_example.py
@@ -11,7 +11,7 @@ shutil.copy("conan.lock", "examples/cpp/regression/conan.lock")
 
 with chdir("examples/cpp/regression"):
     cppstd = "17" if platform.system() == "Windows" else "gnu17"
-    run(f"conan install -b=missing -s:a compiler.cppstd={cppstd} --update")
+    run(f"conan install -b=missing -b=libtorch/* -s:a compiler.cppstd={cppstd} --update")
 
     if platform.system() == "Windows":
         run("cmake --preset conan-default")


### PR DESCRIPTION
Confirmed that the build fails on Windows.

While the pyenv is set correctly and the python packages are installed:
```
libtorch/2.9.1: RUN: C:\hostedtoolcache\windows\Python\3.11.9\x64\python.exe -m venv C:\Users\runneradmin\.conan2\p\b\libto555eb080a31c4\b\build\conan_pyenv

WARN: deprecated: 'PipEnv()' is deprecated, use 'PyEnv()'
libtorch/2.9.1: RUN: C:/Users/runneradmin/.conan2/p/b/libto555eb080a31c4/b/build/conan_pyenv/Scripts/python.exe -m pip install --disable-pip-version-check "pyyaml" "typing-extensions"
Collecting pyyaml
  Using cached pyyaml-6.0.3-cp311-cp311-win_amd64.whl.metadata (2.4 kB)
Collecting typing-extensions
  Downloading typing_extensions-4.15.0-py3-none-any.whl.metadata (3.3 kB)
Using cached pyyaml-6.0.3-cp311-cp311-win_amd64.whl (158 kB)
Downloading typing_extensions-4.15.0-py3-none-any.whl (44 kB)
   ---------------------------------------- 44.6/44.6 kB 554.4 kB/s eta 0:00:00
Installing collected packages: typing-extensions, pyyaml
Successfully installed pyyaml-6.0.3 typing-extensions-4.15.0
```
The python interpreter used by libtorch is the one from the system, not the one from the pyenv virtual env:
```
-- Found Python: C:/hostedtoolcache/windows/Python/3.11.9/x64/python3.exe (found version "3.11.9") found components: Interpreter
```