### PR TITLE
Add package signing plugin example using Sigstore's cosign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,7 @@ jobs:
         run: brew install automake autoconf
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.8.2
-        with:
-          cosign-release: v3.0.0
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Install Conan
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install automake autoconf
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.2
+        with:
+          cosign-release: v3.0.0
+
       - name: Install Conan
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,5 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
+          COSIGN_PASSWORD: ""
         run: python -u "${{ github.workspace }}/.github/run_ci_tests.py"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sources for the [examples section](https://docs.conan.io/2/examples.html) of the
 
 ### [Conanfile methods](examples/conanfile)
 
-### [Conan extensions](examples/consuming_packages)
+### [Conan extensions](examples/extensions)
 
 ### [Conan recipe tools](examples/tools)
 

--- a/examples/extensions/README.md
+++ b/examples/extensions/README.md
@@ -8,6 +8,14 @@
 
 - Learn how to create a custom deployer in Conan. [Docs](https://docs.conan.io/2/reference/extensions/deployers.html)
 
-### [Package signing plugin example with OpenSSL](plugins/openssl_sign)
+### Package signing plugin examples
 
-- Learn how to create a package signing plugin in Conan. [Docs](https://docs.conan.io/2/reference/extensions/package_signing.html)
+- Learn how to implement Conan's package signing plugin. [Docs](https://docs.conan.io/2/reference/extensions/package_signing.html)
+
+#### [OpenSSL](plugins/openssl_sign)
+
+- Sign and verify with `openssl dgst` and PEM keys.
+
+#### [Sigstore (cosign)](plugins/sigstore_sign)
+
+- Sign and verify packages with [Sigstore](https://www.sigstore.dev/) using [cosign](https://github.com/sigstore/cosign).

--- a/examples/extensions/plugins/sigstore_sign/README.md
+++ b/examples/extensions/plugins/sigstore_sign/README.md
@@ -17,7 +17,7 @@ This example implements Conan’s signing hook with [cosign](https://github.com/
 
 ### Signing method name
 
-The plugin records **`method`: `sigstore-cosign`** in signature metadata (`pkgsign-signatures.json`). That string is the convention for this cosign-based backend: keep it stable so verifiers and other tooling can recognize and handle this format alongside other methods (`openssl-dgst`, `gpg`, etc.).
+The plugin records **`method`: `sigstore`** in signature metadata (`pkgsign-signatures.json`). That string is the convention for this cosign-based backend: keep it stable so verifiers and other tooling can recognize and handle this format alongside other methods (`openssl-dgst`, `gpg`, etc.).
 
 ### Try it
 

--- a/examples/extensions/plugins/sigstore_sign/README.md
+++ b/examples/extensions/plugins/sigstore_sign/README.md
@@ -1,0 +1,40 @@
+
+## Package signing plugin example with Sigstore (cosign)
+
+> **This is not a production-ready plugin.** It is a **minimal example** only, to show how you might wire Conan’s package signing hook to cosign. For real deployments, harden key handling, configuration, error handling, and policy before relying on it.
+
+> **_SECURITY NOTE:_**  This example stores a private key next to the plugin for simplicity. **Do not do this in production**.
+> Instead, load the signing key from environment variables or a secret manager, or delegate signing to a remote signing service.
+> **Always keep the private key out of the Conan cache and out of source control**.
+
+This example implements Conan’s signing hook with [cosign](https://github.com/sigstore/cosign) in **offline** mode (no public Rekor upload), using the smallest amount of code that still demonstrates sign and verify.
+
+
+### Requirements
+
+- **`cosign`** on your `PATH` (required >= 3.0.0 version). See [releases](https://github.com/sigstore/cosign/releases).
+- **`COSIGN_PASSWORD`:** Required environment variable for non-interactive signing (CI, scripts). Set it to the password for your cosign private key. If the key has no password, set it to an empty value (for example `export COSIGN_PASSWORD=` in bash). Cosign reads this variable instead of prompting.
+
+### Signing method name
+
+The plugin records **`method`: `sigstore-cosigin`** in signature metadata (`pkgsign-signatures.json`). That string is the convention for this cosign-based backend: keep it stable so verifiers and other tooling can recognize and handle this format alongside other methods (`openssl-dgst`, `gpg`, etc.).
+
+### Try it
+
+1. Copy `sign.py`, `signing-config.json`, and your provider key directory into `CONAN_HOME/extensions/plugins/sign/` (same layout as this folder: `sign.py` and `signing-config.json` at the root of `sign/`, keys under `my-organization/`).
+2. Generate keys and move them into `my-organization/` as `signing.key` / `signing.pub`:
+
+   ```bash
+   cosign generate-key-pair --output-key-prefix signing
+   ```
+
+3. Create and sign a package:
+
+   ```bash
+   conan new cmake_lib -d name=hello -d version=1.0
+   conan create
+   conan cache sign hello/1.0
+   conan cache verify hello/1.0
+   ```
+
+Packages downloaded from a remote are verified automatically when verification is enabled (e.g. `conan install`), as with any signing plugin.

--- a/examples/extensions/plugins/sigstore_sign/README.md
+++ b/examples/extensions/plugins/sigstore_sign/README.md
@@ -17,7 +17,7 @@ This example implements Conan’s signing hook with [cosign](https://github.com/
 
 ### Signing method name
 
-The plugin records **`method`: `sigstore-cosigin`** in signature metadata (`pkgsign-signatures.json`). That string is the convention for this cosign-based backend: keep it stable so verifiers and other tooling can recognize and handle this format alongside other methods (`openssl-dgst`, `gpg`, etc.).
+The plugin records **`method`: `sigstore-cosign`** in signature metadata (`pkgsign-signatures.json`). That string is the convention for this cosign-based backend: keep it stable so verifiers and other tooling can recognize and handle this format alongside other methods (`openssl-dgst`, `gpg`, etc.).
 
 ### Try it
 

--- a/examples/extensions/plugins/sigstore_sign/ci_test_example.py
+++ b/examples/extensions/plugins/sigstore_sign/ci_test_example.py
@@ -16,6 +16,7 @@ if conan_version >= "2.26.0-dev":
         cwd=provider_folder,
         env={**os.environ, "COSIGN_PASSWORD": ""},
         check=True,
+        env=os.environ.copy()
     )
 
     os.environ["COSIGN_PASSWORD"] = ""

--- a/examples/extensions/plugins/sigstore_sign/ci_test_example.py
+++ b/examples/extensions/plugins/sigstore_sign/ci_test_example.py
@@ -9,17 +9,11 @@ if conan_version >= "2.26.0-dev":
     current_dir = os.path.abspath(os.path.dirname(__file__))
     provider_folder = os.path.join(current_dir, "my-organization")
     os.makedirs(provider_folder, exist_ok=True)
+    os.chdir(provider_folder)
 
-    subprocess.run(
-        "cosign generate-key-pair --output-key-prefix signing",
-        shell=True,
-        cwd=provider_folder,
-        env={**os.environ, "COSIGN_PASSWORD": ""},
-        check=True,
-        env=os.environ.copy()
-    )
+    run("cosign generate-key-pair --output-key-prefix signing")
 
-    os.environ["COSIGN_PASSWORD"] = ""
+    os.chdir("..")
 
     run(f"conan config install {current_dir} -t dir --target-folder extensions/plugins/sign")
 

--- a/examples/extensions/plugins/sigstore_sign/ci_test_example.py
+++ b/examples/extensions/plugins/sigstore_sign/ci_test_example.py
@@ -1,0 +1,36 @@
+import os
+import shutil
+import subprocess
+
+from conan import conan_version
+from test.examples_tools import run
+
+if conan_version >= "2.26.0-dev":
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    provider_folder = os.path.join(current_dir, "my-organization")
+    os.makedirs(provider_folder, exist_ok=True)
+
+    subprocess.run(
+        "cosign generate-key-pair --output-key-prefix signing",
+        shell=True,
+        cwd=provider_folder,
+        env={**os.environ, "COSIGN_PASSWORD": ""},
+        check=True,
+    )
+
+    os.environ["COSIGN_PASSWORD"] = ""
+
+    run(f"conan config install {current_dir} -t dir --target-folder extensions/plugins/sign")
+
+    run("conan new cmake_lib -d name=hello -d version=1.0")
+    run("conan create")
+
+    output = run("conan cache sign hello/1.0")
+    assert "Package signed for reference hello/1.0" in output
+    assert "[Package sign] Summary: OK=2, FAILED=0" in output
+    output = run("conan cache verify hello/1.0")
+    assert "Package verified for reference hello/1.0" in output
+    assert "[Package sign] Summary: OK=2, FAILED=0" in output
+
+    conan_home = run("conan config home").strip()
+    shutil.rmtree(os.path.join(conan_home, "extensions", "plugins", "sign"))

--- a/examples/extensions/plugins/sigstore_sign/ci_test_example.py
+++ b/examples/extensions/plugins/sigstore_sign/ci_test_example.py
@@ -5,7 +5,7 @@ import subprocess
 from conan import conan_version
 from test.examples_tools import run
 
-if conan_version >= "2.26.0-dev":
+if conan_version >= "2.26.0":
     current_dir = os.path.abspath(os.path.dirname(__file__))
     provider_folder = os.path.join(current_dir, "my-organization")
     os.makedirs(provider_folder, exist_ok=True)

--- a/examples/extensions/plugins/sigstore_sign/sign.py
+++ b/examples/extensions/plugins/sigstore_sign/sign.py
@@ -15,11 +15,11 @@ example), next to this file under ``CONAN_HOME/extensions/plugins/sign/``.
 For non-interactive signing (CI, automation), set ``COSIGN_PASSWORD`` to the key password (empty string if the
 key has no password).
 
-This plugin explicitly disables the usage of Rekor public log by diabling it in the signining and verify processes
+This plugin explicitly disables the usage of Rekor public log by disabling it in the signining and verify processes
 
 SECURITY NOTE:
     This example keeps keys beside the plugin for clarity only. **Do not do this in production** — use a
-    secret store, or simmilar, and never commit private keys.
+    secret store, or similar, and never commit private keys.
 """
 
 import json

--- a/examples/extensions/plugins/sigstore_sign/sign.py
+++ b/examples/extensions/plugins/sigstore_sign/sign.py
@@ -30,7 +30,7 @@ from conan.api.output import ConanOutput
 from conan.errors import ConanException
 
 # Stored in pkgsign-signatures.json as ``method``; use a stable, distinctive name across your org/ecosystem.
-SIGNING_METHOD = "sigstore-cosigin"
+SIGNING_METHOD = "sigstore-cosign
 BUNDLE_FILENAME = "artifact.sigstore.json"
 
 

--- a/examples/extensions/plugins/sigstore_sign/sign.py
+++ b/examples/extensions/plugins/sigstore_sign/sign.py
@@ -1,0 +1,149 @@
+"""
+Example-only plugin to sign and verify Conan packages with Sigstore (cosign).
+
+**Not production-ready** — illustrative code to show how the signing hook can call cosign. Adapt and harden before any real use.
+
+Requires **cosign 3.0.0 or newer** on ``PATH`` (https://github.com/sigstore/cosign/releases).
+
+Generate a key pair (you will be prompted for a password unless you rely on ``COSIGN_PASSWORD``):
+
+    $ cosign generate-key-pair --output-key-prefix signing
+
+Place ``signing.key`` and ``signing.pub`` in a folder named after your provider (``my-organization`` in this
+example), next to this file under ``CONAN_HOME/extensions/plugins/sign/``.
+
+For non-interactive signing (CI, automation), set ``COSIGN_PASSWORD`` to the key password (empty string if the
+key has no password).
+
+This plugin explicitly disables the usage of Rekor public log by diabling it in the signining and verify processes
+
+SECURITY NOTE:
+    This example keeps keys beside the plugin for clarity only. **Do not do this in production** — use a
+    secret store, or simmilar, and never commit private keys.
+"""
+
+import json
+import os
+import subprocess
+
+from conan.api.output import ConanOutput
+from conan.errors import ConanException
+
+# Stored in pkgsign-signatures.json as ``method``; use a stable, distinctive name across your org/ecosystem.
+SIGNING_METHOD = "sigstore-cosigin"
+BUNDLE_FILENAME = "artifact.sigstore.json"
+
+
+def _signing_config_path():
+    return os.path.join(os.path.dirname(__file__), "signing-config.json")
+
+
+def _run_command(command):
+    ConanOutput().info(f"Running command: {' '.join(command)}")
+    result = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, result.args, output=result.stdout, stderr=result.stderr
+        )
+
+
+def sign(ref, artifacts_folder, signature_folder, **kwargs):
+    provider = "my-organization"
+    manifest_filepath = os.path.join(signature_folder, "pkgsign-manifest.json")
+    bundle_filepath = os.path.join(signature_folder, BUNDLE_FILENAME)
+
+    if os.path.isfile(bundle_filepath):
+        ConanOutput().warning(f"Package {ref.repr_notime()} was already signed (bundle exists)")
+
+    if "COSIGN_PASSWORD" not in os.environ:
+        raise ConanException(
+            "COSIGN_PASSWORD is not set. Set it to your cosign key password (use an empty value if the key "
+            "has no password) so signing can run non-interactively."
+        )
+
+    privkey_filepath = os.path.join(os.path.dirname(__file__), provider, "signing.key")
+    if not os.path.isfile(privkey_filepath):
+        raise ConanException(f"Private key not found at {privkey_filepath}")
+
+    cosign_sign_cmd = [
+        "cosign",
+        "sign-blob",
+        "--key",
+        privkey_filepath,
+        "--bundle",
+        bundle_filepath,
+        "-y",
+        f"--signing-config={_signing_config_path()}",
+        manifest_filepath,
+    ]
+    try:
+        _run_command(cosign_sign_cmd)
+        ConanOutput().success(f"Package signed for reference {ref}")
+    except Exception as exc:
+        raise ConanException(f"Error signing artifact: {exc}") from exc
+
+    return [
+        {
+            "method": SIGNING_METHOD,
+            "provider": provider,
+            "sign_artifacts": {
+                "manifest": "pkgsign-manifest.json",
+                "bundle": BUNDLE_FILENAME,
+            },
+        }
+    ]
+
+
+def verify(ref, artifacts_folder, signature_folder, files, **kwargs):
+    signatures_path = os.path.join(signature_folder, "pkgsign-signatures.json")
+    try:
+        with open(signatures_path, "r", encoding="utf-8") as f:
+            signatures = json.loads(f.read()).get("signatures")
+    except Exception:
+        ConanOutput().warning("Could not verify unsigned package")
+        return
+
+    for signature in signatures:
+        artifacts = signature.get("sign_artifacts") or {}
+        manifest_name = artifacts.get("manifest")
+        bundle_name = artifacts.get("bundle")
+        if not manifest_name or not bundle_name:
+            raise ConanException("Signature entry missing manifest or bundle path")
+
+        manifest_filepath = os.path.join(signature_folder, manifest_name)
+        bundle_filepath = os.path.join(signature_folder, bundle_name)
+        if not os.path.isfile(bundle_filepath):
+            raise ConanException(f"Signature bundle not found at {bundle_filepath}")
+
+        provider = signature.get("provider")
+        pubkey_filepath = os.path.join(os.path.dirname(__file__), provider, "signing.pub")
+        if not os.path.isfile(pubkey_filepath):
+            raise ConanException(f"Public key not found for provider '{provider}'")
+
+        signature_method = signature.get("method")
+        if signature_method == SIGNING_METHOD:
+            cosign_verify_cmd = [
+                "cosign",
+                "verify-blob",
+                "--key",
+                pubkey_filepath,
+                "--bundle",
+                bundle_filepath,
+                "--private-infrastructure=true",
+                manifest_filepath,
+            ]
+            try:
+                _run_command(cosign_verify_cmd)
+                ConanOutput().success(f"Package verified for reference {ref}")
+            except Exception as exc:
+                raise ConanException(f"Error verifying signature {bundle_filepath}: {exc}") from exc
+        else:
+            raise ConanException(
+                f"Sign method {signature_method!r} not supported. Cannot verify package"
+            )

--- a/examples/extensions/plugins/sigstore_sign/sign.py
+++ b/examples/extensions/plugins/sigstore_sign/sign.py
@@ -15,7 +15,7 @@ example), next to this file under ``CONAN_HOME/extensions/plugins/sign/``.
 For non-interactive signing (CI, automation), set ``COSIGN_PASSWORD`` to the key password (empty string if the
 key has no password).
 
-This plugin explicitly disables the usage of Rekor public log by disabling it in the signining and verify processes
+This plugin explicitly disables the usage of Rekor public log by disabling it in the signing and verification processes
 
 SECURITY NOTE:
     This example keeps keys beside the plugin for clarity only. **Do not do this in production** — use a

--- a/examples/extensions/plugins/sigstore_sign/sign.py
+++ b/examples/extensions/plugins/sigstore_sign/sign.py
@@ -30,7 +30,7 @@ from conan.api.output import ConanOutput
 from conan.errors import ConanException
 
 # Stored in pkgsign-signatures.json as ``method``; use a stable, distinctive name across your org/ecosystem.
-SIGNING_METHOD = "sigstore-cosign"
+SIGNING_METHOD = "sigstore"
 BUNDLE_FILENAME = "artifact.sigstore.json"
 
 

--- a/examples/extensions/plugins/sigstore_sign/sign.py
+++ b/examples/extensions/plugins/sigstore_sign/sign.py
@@ -30,7 +30,7 @@ from conan.api.output import ConanOutput
 from conan.errors import ConanException
 
 # Stored in pkgsign-signatures.json as ``method``; use a stable, distinctive name across your org/ecosystem.
-SIGNING_METHOD = "sigstore-cosign
+SIGNING_METHOD = "sigstore-cosign"
 BUNDLE_FILENAME = "artifact.sigstore.json"
 
 

--- a/examples/extensions/plugins/sigstore_sign/signing-config.json
+++ b/examples/extensions/plugins/sigstore_sign/signing-config.json
@@ -1,0 +1,1 @@
+{"mediaType":"application/vnd.dev.sigstore.signingconfig.v0.2+json","rekorTlogConfig":{},"tsaConfig":{}}


### PR DESCRIPTION
Add sigstore cosign package signing plugin example, similar to the openssl one introduced at #207 