### PR TITLE
Pin windows runner to 2022

### DIFF
--- a/.github/run_ci_tests.py
+++ b/.github/run_ci_tests.py
@@ -59,6 +59,10 @@ def find_affected_directories(base_ref) -> list:
         if file:
             print(file)
 
+    if any(".github/workflows/ci.yml" in f for f in changed_files):
+        print("\nCI workflow changed - running all examples")
+        return []
+
     affected_dirs = set()
 
     for file_path in changed_files:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-2025]
         conan-version: [release, develop]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2025]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         conan-version: [release, develop]
     runs-on: ${{ matrix.os }}
     steps:
@@ -45,6 +45,12 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.14
         with:
           cmake-version: "3.23"
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
 
       - name: Install Bazel
         uses: bazel-contrib/setup-bazel@0.15.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
         conan-version: [release, develop]
     runs-on: ${{ matrix.os }}
     steps:

--- a/examples/libraries/protobuf/serialization/requirements.txt
+++ b/examples/libraries/protobuf/serialization/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==4.23.1
+protobuf>=5.27.2

--- a/tutorial/developing_packages/editable_packages/ci_test_example.py
+++ b/tutorial/developing_packages/editable_packages/ci_test_example.py
@@ -49,11 +49,11 @@ with chdir("hello"):
 
 with chdir("say"):
     replace(os.path.join("src", "say.cpp"), "Hello World", "Bye World")
-    if platform.system() == "Windows":        
-        run(f"cmake --build --preset {prefix_preset_name}release")
-        run(f"cmake --build --preset {prefix_preset_name}debug")
+    if platform.system() == "Windows":
+        run(f"cmake --build --preset {prefix_preset_name}release --clean-first")
+        run(f"cmake --build --preset {prefix_preset_name}debug --clean-first")
     else:
-        run(f"cmake --build --preset {prefix_preset_name}release")
+        run(f"cmake --build --preset {prefix_preset_name}release --clean-first")
 
 with chdir("hello"):
     # Clean hello build to ensure it uses the updated say library


### PR DESCRIPTION
Also 
- bumping protobuf because some dependabot warnings
- making that if you change the workflow all examples will be tested
- add Java 17 for Gradle 9.5.1 compatibility for `cross_build/android/raylib` example