### PR TITLE
Remove passing Python3_EXECUTABLE from recipe for conan-py-build example

### DIFF
--- a/examples/extensions/python_build_backend/conanfile.py
+++ b/examples/extensions/python_build_backend/conanfile.py
@@ -1,12 +1,11 @@
-import sys
-
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.cmake import CMake, cmake_layout
 
 
 class MyAdderConan(ConanFile):
     name = "myadder"
     settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain", "CMakeDeps"
 
     def layout(self):
         cmake_layout(self)
@@ -14,14 +13,6 @@ class MyAdderConan(ConanFile):
     def requirements(self):
         self.requires("pybind11/3.0.1")
         self.requires("fmt/12.1.0")
-
-    def generate(self):
-        # Keep CMake on the same Python interpreter pip uses
-        tc = CMakeToolchain(self)
-        tc.cache_variables["Python3_EXECUTABLE"] = sys.executable
-        tc.generate()
-        deps = CMakeDeps(self)
-        deps.generate()
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
This is now automatically provided by the backend starting in version 0.6.1

Related to:
- https://github.com/conan-io/docs/pull/4505
- https://github.com/conan-io/conan-py-build/pull/58